### PR TITLE
Fix transitive assembly resolution by adding directory-based dependen…

### DIFF
--- a/src/runtime/Inspection/DependencyResolvingLoadContext.cs
+++ b/src/runtime/Inspection/DependencyResolvingLoadContext.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.Loader;
 
@@ -6,7 +7,7 @@ namespace Sherlock.MCP.Runtime.Inspection;
 public sealed class DependencyResolvingLoadContext : AssemblyLoadContext, IDisposable
 {
     private readonly string _baseDirectory;
-    private readonly Dictionary<string, Assembly> _loadedAssemblies = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, Assembly> _loadedAssemblies = new(StringComparer.OrdinalIgnoreCase);
 
     public DependencyResolvingLoadContext(string name, string baseDirectory)
         : base(name, isCollectible: true)
@@ -15,7 +16,11 @@ public sealed class DependencyResolvingLoadContext : AssemblyLoadContext, IDispo
         Resolving += OnResolving;
     }
 
-    public void Dispose() => Unload();
+    public void Dispose()
+    {
+        Resolving -= OnResolving;
+        Unload();
+    }
 
     private Assembly? OnResolving(AssemblyLoadContext context, AssemblyName name)
     {

--- a/src/runtime/Inspection/DependencyResolvingLoadContext.cs
+++ b/src/runtime/Inspection/DependencyResolvingLoadContext.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Sherlock.MCP.Runtime.Inspection;
+
+public sealed class DependencyResolvingLoadContext : AssemblyLoadContext, IDisposable
+{
+    private readonly string _baseDirectory;
+    private readonly Dictionary<string, Assembly> _loadedAssemblies = new(StringComparer.OrdinalIgnoreCase);
+
+    public DependencyResolvingLoadContext(string name, string baseDirectory)
+        : base(name, isCollectible: true)
+    {
+        _baseDirectory = baseDirectory;
+        Resolving += OnResolving;
+    }
+
+    public void Dispose() => Unload();
+
+    private Assembly? OnResolving(AssemblyLoadContext context, AssemblyName name)
+    {
+        if (string.IsNullOrEmpty(name.Name))
+            return null;
+
+        if (_loadedAssemblies.TryGetValue(name.Name, out var cached))
+            return cached;
+
+        var assemblyPath = FindAssemblyInDirectory(name);
+        if (assemblyPath == null)
+            return null;
+
+        try
+        {
+            var assembly = LoadFromAssemblyPath(assemblyPath);
+            _loadedAssemblies[name.Name] = assembly;
+            return assembly;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private string? FindAssemblyInDirectory(AssemblyName name)
+    {
+        if (string.IsNullOrEmpty(name.Name))
+            return null;
+
+        var dllPath = Path.Combine(_baseDirectory, $"{name.Name}.dll");
+        if (File.Exists(dllPath))
+            return dllPath;
+
+        var exePath = Path.Combine(_baseDirectory, $"{name.Name}.exe");
+        if (File.Exists(exePath))
+            return exePath;
+
+        return null;
+    }
+}

--- a/src/runtime/Inspection/IsolatedRuntimeInspectionContext.cs
+++ b/src/runtime/Inspection/IsolatedRuntimeInspectionContext.cs
@@ -1,31 +1,48 @@
 using System.Reflection;
-using System.Runtime.Loader;
 
 namespace Sherlock.MCP.Runtime.Inspection;
 
-// Placeholder that mirrors MetadataOnlyInspectionContext until isolation is added
 public sealed class IsolatedRuntimeInspectionContext : IAssemblyInspectionContext
 {
-    private readonly AssemblyLoadContext _alc;
+    private readonly DependencyResolvingLoadContext _alc;
 
     public IsolatedRuntimeInspectionContext(string assemblyPath)
     {
-        _alc = new AssemblyLoadContext($"sherlock_{Path.GetFileNameWithoutExtension(assemblyPath)}", isCollectible: true);
-        using var stream = File.OpenRead(assemblyPath);
-        var bytes = new byte[stream.Length];
-        _ = stream.Read(bytes, 0, bytes.Length);
-        Assembly = _alc.LoadFromStream(new MemoryStream(bytes));
+        var assemblyDirectory = Path.GetDirectoryName(assemblyPath) ?? ".";
+        var contextName = $"sherlock_{Path.GetFileNameWithoutExtension(assemblyPath)}_{Guid.NewGuid():N}";
+
+        _alc = new DependencyResolvingLoadContext(contextName, assemblyDirectory);
+        Assembly = _alc.LoadFromAssemblyPath(Path.GetFullPath(assemblyPath));
     }
 
     public Assembly Assembly { get; }
 
-    public IEnumerable<Type> GetTypes() => Assembly.GetTypes();
+    public IEnumerable<Type> GetTypes()
+    {
+        try
+        {
+            return Assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(t => t != null)!;
+        }
+    }
 
-    public MemberInfo[] GetMembers(Type type, BindingFlags flags) => type.GetMembers(flags);
+    public MemberInfo[] GetMembers(Type type, BindingFlags flags)
+    {
+        try
+        {
+            return type.GetMembers(flags);
+        }
+        catch (TypeLoadException)
+        {
+            return [];
+        }
+    }
 
     public void Dispose()
     {
         _alc.Unload();
     }
 }
-

--- a/src/runtime/Inspection/IsolatedRuntimeInspectionContext.cs
+++ b/src/runtime/Inspection/IsolatedRuntimeInspectionContext.cs
@@ -25,7 +25,7 @@ public sealed class IsolatedRuntimeInspectionContext : IAssemblyInspectionContex
         }
         catch (ReflectionTypeLoadException ex)
         {
-            return ex.Types.Where(t => t != null)!;
+            return ex.Types.Where(t => t != null).Cast<Type>();
         }
     }
 

--- a/src/runtime/Inspection/MetadataOnlyInspectionContext.cs
+++ b/src/runtime/Inspection/MetadataOnlyInspectionContext.cs
@@ -2,7 +2,6 @@ using System.Reflection;
 
 namespace Sherlock.MCP.Runtime.Inspection;
 
-// Minimal placeholder using runtime reflection for now; will switch to MetadataLoadContext.
 public sealed class MetadataOnlyInspectionContext : IAssemblyInspectionContext
 {
     public MetadataOnlyInspectionContext(string assemblyPath)
@@ -12,12 +11,31 @@ public sealed class MetadataOnlyInspectionContext : IAssemblyInspectionContext
 
     public Assembly Assembly { get; }
 
-    public IEnumerable<Type> GetTypes() => Assembly.GetTypes();
+    public IEnumerable<Type> GetTypes()
+    {
+        try
+        {
+            return Assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(t => t != null)!;
+        }
+    }
 
-    public MemberInfo[] GetMembers(Type type, BindingFlags flags) => type.GetMembers(flags);
+    public MemberInfo[] GetMembers(Type type, BindingFlags flags)
+    {
+        try
+        {
+            return type.GetMembers(flags);
+        }
+        catch (TypeLoadException)
+        {
+            return [];
+        }
+    }
 
     public void Dispose()
     {
     }
 }
-

--- a/src/runtime/Inspection/MetadataOnlyInspectionContext.cs
+++ b/src/runtime/Inspection/MetadataOnlyInspectionContext.cs
@@ -19,7 +19,7 @@ public sealed class MetadataOnlyInspectionContext : IAssemblyInspectionContext
         }
         catch (ReflectionTypeLoadException ex)
         {
-            return ex.Types.Where(t => t != null)!;
+            return ex.Types.Where(t => t != null).Cast<Type>();
         }
     }
 

--- a/src/server/Sherlock.MCP.Server.csproj
+++ b/src/server/Sherlock.MCP.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/server/Tools/ReflectionTools.cs
+++ b/src/server/Tools/ReflectionTools.cs
@@ -36,7 +36,7 @@ public static class ReflectionTools
             }
             catch (ReflectionTypeLoadException ex)
             {
-                allTypes = ex.Types.Where(t => t != null).ToArray()!;
+                allTypes = ex.Types.Where(t => t != null).Cast<Type>().ToArray();
             }
 
             // Pagination logic
@@ -219,7 +219,7 @@ public static class ReflectionTools
             }
             catch (ReflectionTypeLoadException ex)
             {
-                exportedTypes = ex.Types.Where(t => t != null).ToArray()!;
+                exportedTypes = ex.Types.Where(t => t != null).Cast<Type>().ToArray();
             }
 
             var type = assembly.GetType(typeName)
@@ -400,7 +400,7 @@ public static class ReflectionTools
             }
             catch (ReflectionTypeLoadException ex)
             {
-                exportedTypes = ex.Types.Where(t => t != null).ToArray()!;
+                exportedTypes = ex.Types.Where(t => t != null).Cast<Type>().ToArray();
             }
 
             var type = assembly.GetType(typeName)

--- a/src/server/Tools/ReflectionTools.cs
+++ b/src/server/Tools/ReflectionTools.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Text.Json;
 using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Inspection;
 using Sherlock.MCP.Server.Shared;
 
 namespace Sherlock.MCP.Server.Tools;
@@ -26,8 +27,17 @@ public static class ReflectionTools
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
-            var assembly = Assembly.LoadFrom(assemblyPath);
-            var allTypes = assembly.GetExportedTypes();
+            using var ctx = InspectionContextFactory.Create(assemblyPath);
+            var assembly = ctx.Assembly;
+            Type[] allTypes;
+            try
+            {
+                allTypes = assembly.GetExportedTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                allTypes = ex.Types.Where(t => t != null).ToArray()!;
+            }
 
             // Pagination logic
             var defaultPageSize = runtimeOptions.GetMaxItemsForTool("AnalyzeAssembly");
@@ -200,9 +210,20 @@ public static class ReflectionTools
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
-            var assembly = Assembly.LoadFrom(assemblyPath);
+            using var ctx = InspectionContextFactory.Create(assemblyPath);
+            var assembly = ctx.Assembly;
+            Type[] exportedTypes;
+            try
+            {
+                exportedTypes = assembly.GetExportedTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                exportedTypes = ex.Types.Where(t => t != null).ToArray()!;
+            }
+
             var type = assembly.GetType(typeName)
-                ?? assembly.GetExportedTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal) || string.Equals(t.Name, typeName, StringComparison.Ordinal));
+                ?? exportedTypes.FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal) || string.Equals(t.Name, typeName, StringComparison.Ordinal));
 
             if (type == null)
                 return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
@@ -370,10 +391,20 @@ public static class ReflectionTools
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
-            var assembly = Assembly.LoadFrom(assemblyPath);
+            using var ctx = InspectionContextFactory.Create(assemblyPath);
+            var assembly = ctx.Assembly;
+            Type[] exportedTypes;
+            try
+            {
+                exportedTypes = assembly.GetExportedTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                exportedTypes = ex.Types.Where(t => t != null).ToArray()!;
+            }
+
             var type = assembly.GetType(typeName)
-                ?? assembly.GetExportedTypes()
-                    .FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
+                ?? exportedTypes.FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
                                        || string.Equals(t.Name, typeName, StringComparison.Ordinal));
             if (type == null)
                 return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");

--- a/src/unit-tests/TransitiveAssemblyResolutionTests.cs
+++ b/src/unit-tests/TransitiveAssemblyResolutionTests.cs
@@ -1,0 +1,97 @@
+using Sherlock.MCP.Runtime.Inspection;
+using System.Reflection;
+
+namespace Sherlock.MCP.Tests;
+
+public class TransitiveAssemblyResolutionTests
+{
+    [Fact]
+    public void IsolatedContext_Loads_Assembly_Successfully()
+    {
+        var testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+        using var ctx = new IsolatedRuntimeInspectionContext(testAssemblyPath);
+
+        Assert.NotNull(ctx.Assembly);
+        Assert.Equal(testAssemblyPath, ctx.Assembly.Location);
+    }
+
+    [Fact]
+    public void IsolatedContext_GetTypes_Returns_Types()
+    {
+        var testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+        using var ctx = new IsolatedRuntimeInspectionContext(testAssemblyPath);
+        var types = ctx.GetTypes().ToArray();
+
+        Assert.True(types.Length > 0);
+        Assert.Contains(types, t => t.Name == nameof(TransitiveAssemblyResolutionTests));
+    }
+
+    [Fact]
+    public void MetadataOnlyContext_Loads_Assembly_Successfully()
+    {
+        var testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+        using var ctx = new MetadataOnlyInspectionContext(testAssemblyPath);
+
+        Assert.NotNull(ctx.Assembly);
+    }
+
+    [Fact]
+    public void MetadataOnlyContext_GetTypes_Returns_Types()
+    {
+        var testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+        using var ctx = new MetadataOnlyInspectionContext(testAssemblyPath);
+        var types = ctx.GetTypes().ToArray();
+
+        Assert.True(types.Length > 0);
+        Assert.Contains(types, t => t.Name == nameof(TransitiveAssemblyResolutionTests));
+    }
+
+    [Fact]
+    public void DependencyResolvingLoadContext_Loads_Assembly_From_Directory()
+    {
+        var assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var contextName = $"test_{Guid.NewGuid():N}";
+
+        using var alc = new DependencyResolvingLoadContext(contextName, assemblyDir);
+        var testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+        var loaded = alc.LoadFromAssemblyPath(testAssemblyPath);
+
+        Assert.NotNull(loaded);
+    }
+
+    [Fact]
+    public void InspectionContextFactory_Creates_MetadataOnly_By_Default()
+    {
+        var testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+        using var ctx = InspectionContextFactory.Create(testAssemblyPath);
+
+        Assert.IsType<MetadataOnlyInspectionContext>(ctx);
+    }
+
+    [Fact]
+    public void InspectionContextFactory_Creates_Isolated_When_Forced()
+    {
+        var testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+        using var ctx = InspectionContextFactory.Create(testAssemblyPath, forceRuntimeLoad: true);
+
+        Assert.IsType<IsolatedRuntimeInspectionContext>(ctx);
+    }
+
+    [Fact]
+    public void IsolatedContext_GetMembers_Returns_Members()
+    {
+        var testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+        using var ctx = new IsolatedRuntimeInspectionContext(testAssemblyPath);
+        var testType = ctx.GetTypes().First(t => t.Name == nameof(TransitiveAssemblyResolutionTests));
+        var members = ctx.GetMembers(testType, BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+        Assert.True(members.Length > 0);
+    }
+}


### PR DESCRIPTION
…cy resolver

Addresses issue #14 where assemblies with transitive dependencies in the same directory would fail to load. Adds graceful error handling for partial type loading.