### PR TITLE
fix(runtime): switch inspection path from default ALC to MetadataLoadContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1] - 2026-04-17
+
+### Fixed
+
+- Inspection tools no longer fail with `Could not load file or assembly` when inspected types reference attributes whose dependencies are absent on disk. The default inspection context now uses `System.Reflection.MetadataLoadContext` (inspection-only) instead of loading assemblies into the default `AssemblyLoadContext`, so attribute metadata is readable without resolving the attribute's runtime dependencies. Six MLC-incompatible reflection patterns (attribute lookups, `typeof()` type comparisons, `GetBaseDefinition`, `DefaultValue`) were migrated to MLC-safe equivalents. (#19)
+
 ## [2.7.0] - 2025-01-18
 
 This is the baseline release for conventional commits adoption. Prior versions were not tracked with structured release notes.
@@ -27,4 +33,5 @@ This is the baseline release for conventional commits adoption. Prior versions w
 
 Versions prior to 2.7.0 were not tracked with conventional commits. This changelog begins with 2.7.0 as the baseline.
 
+[2.7.1]: https://github.com/jcucci/dotnet-sherlock-mcp/releases/tag/v2.7.1
 [2.7.0]: https://github.com/jcucci/dotnet-sherlock-mcp/releases/tag/v2.7.0

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/jcucci/dotnet-sherlock-mcp",
     "source": "github"
   },
-  "version": "2.7.0",
+  "version": "2.7.1",
   "packages": [
     {
       "registryType": "nuget",
       "identifier": "Sherlock.MCP.Server",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/runtime/AttributeUtils.cs
+++ b/src/runtime/AttributeUtils.cs
@@ -66,8 +66,18 @@ public static class AttributeUtils
             if (usage == null) return (false, AttributeTargets.All);
 
             var validOn = AttributeTargets.All;
-            if (usage.ConstructorArguments.Count > 0 && usage.ConstructorArguments[0].Value is int targets)
-                validOn = (AttributeTargets)targets;
+            if (usage.ConstructorArguments.Count > 0)
+            {
+                var value = usage.ConstructorArguments[0].Value;
+                if (value is AttributeTargets targets)
+                {
+                    validOn = targets;
+                }
+                else if (value is byte or sbyte or short or ushort or int or uint or long or ulong)
+                {
+                    validOn = (AttributeTargets)System.Convert.ToInt64(value);
+                }
+            }
 
             var allowMultiple = false;
             foreach (var named in usage.NamedArguments)

--- a/src/runtime/AttributeUtils.cs
+++ b/src/runtime/AttributeUtils.cs
@@ -46,14 +46,44 @@ public static class AttributeUtils
             );
 
         var attributeType = attributeData.AttributeType;
-        var attributeUsage = attributeType.GetCustomAttribute<AttributeUsageAttribute>();
+        var (allowMultiple, validOn) = ReadAttributeUsage(attributeType);
 
         return new AttributeInfo(
             AttributeType: attributeType.FullName ?? attributeType.Name,
             ConstructorArguments: constructorArgs,
             NamedArguments: namedArgs,
-            AllowMultiple: attributeUsage?.AllowMultiple ?? false,
-            ValidOn: attributeUsage?.ValidOn ?? AttributeTargets.All
+            AllowMultiple: allowMultiple,
+            ValidOn: validOn
         );
+    }
+
+    private static (bool AllowMultiple, AttributeTargets ValidOn) ReadAttributeUsage(Type attributeType)
+    {
+        try
+        {
+            var usage = attributeType.GetCustomAttributesData()
+                .FirstOrDefault(a => a.AttributeType.FullName == "System.AttributeUsageAttribute");
+            if (usage == null) return (false, AttributeTargets.All);
+
+            var validOn = AttributeTargets.All;
+            if (usage.ConstructorArguments.Count > 0 && usage.ConstructorArguments[0].Value is int targets)
+                validOn = (AttributeTargets)targets;
+
+            var allowMultiple = false;
+            foreach (var named in usage.NamedArguments)
+            {
+                if (named.MemberName == "AllowMultiple" && named.TypedValue.Value is bool b)
+                {
+                    allowMultiple = b;
+                    break;
+                }
+            }
+
+            return (allowMultiple, validOn);
+        }
+        catch
+        {
+            return (false, AttributeTargets.All);
+        }
     }
 }

--- a/src/runtime/Inspection/MetadataOnlyInspectionContext.cs
+++ b/src/runtime/Inspection/MetadataOnlyInspectionContext.cs
@@ -4,9 +4,14 @@ namespace Sherlock.MCP.Runtime.Inspection;
 
 public sealed class MetadataOnlyInspectionContext : IAssemblyInspectionContext
 {
+    private readonly MetadataLoadContext _mlc;
+
     public MetadataOnlyInspectionContext(string assemblyPath)
     {
-        Assembly = Assembly.LoadFrom(assemblyPath);
+        var resolver = MetadataResolverFactory.Create(assemblyPath);
+        var coreAssemblyName = typeof(object).Assembly.GetName().Name;
+        _mlc = new MetadataLoadContext(resolver, coreAssemblyName);
+        Assembly = _mlc.LoadFromAssemblyPath(Path.GetFullPath(assemblyPath));
     }
 
     public Assembly Assembly { get; }
@@ -35,7 +40,5 @@ public sealed class MetadataOnlyInspectionContext : IAssemblyInspectionContext
         }
     }
 
-    public void Dispose()
-    {
-    }
+    public void Dispose() => _mlc.Dispose();
 }

--- a/src/runtime/Inspection/MetadataResolverFactory.cs
+++ b/src/runtime/Inspection/MetadataResolverFactory.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Sherlock.MCP.Runtime.Inspection;
+
+internal static class MetadataResolverFactory
+{
+    public static PathAssemblyResolver Create(string assemblyPath)
+    {
+        var comparer = StringComparer.OrdinalIgnoreCase;
+        var paths = new HashSet<string>(comparer);
+
+        var fullPath = Path.GetFullPath(assemblyPath);
+        if (File.Exists(fullPath)) paths.Add(fullPath);
+
+        var assemblyDir = Path.GetDirectoryName(fullPath);
+        AddDllsFromDirectory(paths, assemblyDir);
+        AddDllsFromDirectory(paths, RuntimeEnvironment.GetRuntimeDirectory());
+
+        return new PathAssemblyResolver(paths);
+    }
+
+    private static void AddDllsFromDirectory(HashSet<string> paths, string? directory)
+    {
+        if (string.IsNullOrWhiteSpace(directory)) return;
+
+        try
+        {
+            if (!Directory.Exists(directory)) return;
+            foreach (var dll in Directory.EnumerateFiles(directory, "*.dll", SearchOption.TopDirectoryOnly))
+            {
+                try { paths.Add(Path.GetFullPath(dll)); }
+                catch { }
+            }
+        }
+        catch { }
+    }
+}

--- a/src/runtime/MemberAnalysisService.cs
+++ b/src/runtime/MemberAnalysisService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text;
 using Sherlock.MCP.Runtime.Contracts.MemberAnalysis;
@@ -5,12 +6,35 @@ using Sherlock.MCP.Runtime.Inspection;
 
 namespace Sherlock.MCP.Runtime;
 
-public class MemberAnalysisService : IMemberAnalysisService
+public class MemberAnalysisService : IMemberAnalysisService, IDisposable
 {
+    private readonly ConcurrentDictionary<string, IAssemblyInspectionContext> _contexts
+        = new(StringComparer.OrdinalIgnoreCase);
+    private bool _disposed;
+
+    private IAssemblyInspectionContext GetContext(string assemblyPath)
+    {
+        if (_contexts.TryGetValue(assemblyPath, out var existing)) return existing;
+        var created = InspectionContextFactory.Create(assemblyPath);
+        var stored = _contexts.GetOrAdd(assemblyPath, created);
+        if (!ReferenceEquals(stored, created)) created.Dispose();
+        return stored;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        foreach (var ctx in _contexts.Values)
+        {
+            try { ctx.Dispose(); } catch { }
+        }
+        _contexts.Clear();
+    }
 
     public MemberInfo[] GetAllMembers(string assemblyPath, string typeName, MemberFilterOptions? options = null)
     {
-        using var ctx = InspectionContextFactory.Create(assemblyPath);
+        var ctx = GetContext(assemblyPath);
         var type = LoadTypeFromAssembly(ctx.Assembly, typeName, options);
         var bindingFlags = GetBindingFlags(options);
 
@@ -19,7 +43,7 @@ public class MemberAnalysisService : IMemberAnalysisService
 
     public MethodDetails[] GetMethods(string assemblyPath, string typeName, MemberFilterOptions? options = null)
     {
-        using var ctx = InspectionContextFactory.Create(assemblyPath);
+        var ctx = GetContext(assemblyPath);
         var type = LoadTypeFromAssembly(ctx.Assembly, typeName, options);
         var bindingFlags = GetBindingFlags(options);
         var methods = type.GetMethods(bindingFlags);
@@ -66,7 +90,7 @@ public class MemberAnalysisService : IMemberAnalysisService
 
     public PropertyDetails[] GetProperties(string assemblyPath, string typeName, MemberFilterOptions? options = null)
     {
-        using var ctx = InspectionContextFactory.Create(assemblyPath);
+        var ctx = GetContext(assemblyPath);
         var type = LoadTypeFromAssembly(ctx.Assembly, typeName, options);
         var bindingFlags = GetBindingFlags(options);
         var properties = type.GetProperties(bindingFlags);
@@ -110,7 +134,7 @@ public class MemberAnalysisService : IMemberAnalysisService
 
     public FieldDetails[] GetFields(string assemblyPath, string typeName, MemberFilterOptions? options = null)
     {
-        using var ctx = InspectionContextFactory.Create(assemblyPath);
+        var ctx = GetContext(assemblyPath);
         var type = LoadTypeFromAssembly(ctx.Assembly, typeName, options);
         var bindingFlags = GetBindingFlags(options);
         var fields = type.GetFields(bindingFlags);
@@ -154,7 +178,7 @@ public class MemberAnalysisService : IMemberAnalysisService
 
     public EventDetails[] GetEvents(string assemblyPath, string typeName, MemberFilterOptions? options = null)
     {
-        using var ctx = InspectionContextFactory.Create(assemblyPath);
+        var ctx = GetContext(assemblyPath);
         var type = LoadTypeFromAssembly(ctx.Assembly, typeName, options);
         var bindingFlags = GetBindingFlags(options);
         var events = type.GetEvents(bindingFlags);
@@ -192,7 +216,7 @@ public class MemberAnalysisService : IMemberAnalysisService
 
     public ConstructorDetails[] GetConstructors(string assemblyPath, string typeName, MemberFilterOptions? options = null)
     {
-        using var ctx = InspectionContextFactory.Create(assemblyPath);
+        var ctx = GetContext(assemblyPath);
         var type = LoadTypeFromAssembly(ctx.Assembly, typeName, options);
         var bindingFlags = GetBindingFlags(options);
         var constructors = type.GetConstructors(bindingFlags);
@@ -222,7 +246,7 @@ public class MemberAnalysisService : IMemberAnalysisService
         var caseSensitive = options?.CaseSensitive ?? true;
 
         var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
-        var type = assembly.GetType(typeName, false, !caseSensitive);
+        var type = assembly.GetType(typeName);
         if (type == null)
         {
             var allTypes = assembly.GetTypes();
@@ -262,15 +286,21 @@ public class MemberAnalysisService : IMemberAnalysisService
         return parameters.Select(p => new ParameterDetails(
             Name: p.Name ?? "param",
             TypeName: GetFriendlyTypeName(p.ParameterType),
-            DefaultValue: p.HasDefaultValue ? p.DefaultValue?.ToString() : null,
+            DefaultValue: p.HasDefaultValue ? SafeGetRawDefaultValue(p)?.ToString() : null,
             IsOptional: p.IsOptional,
             IsOut: p.IsOut,
             IsRef: p.ParameterType.IsByRef && !p.IsOut,
             IsIn: p.IsIn,
-            IsParams: p.GetCustomAttribute<ParamArrayAttribute>() != null,
+            IsParams: p.CustomAttributes.Any(a => a.AttributeType.FullName == "System.ParamArrayAttribute"),
             Attributes: p.Attributes,
             CustomAttributes: AttributeUtils.FromParameter(p)
         )).ToArray();
+    }
+
+    private static object? SafeGetRawDefaultValue(ParameterInfo p)
+    {
+        try { return p.RawDefaultValue; }
+        catch { return null; }
     }
 
     private static IEnumerable<T> ApplyMemberFilters<T>(IEnumerable<T> source, MemberFilterOptions? options, Func<T, string> nameSelector, Func<T, Sherlock.MCP.Runtime.Contracts.TypeAnalysis.AttributeInfo[]> attrSelector)
@@ -330,27 +360,31 @@ public class MemberAnalysisService : IMemberAnalysisService
             var genericArgs = type.GetGenericArguments().Select(GetFriendlyTypeName);
             return $"{friendlyName}<{string.Join(", ", genericArgs)}>";
         }
-        var builtInTypes = new Dictionary<Type, string>
-        {
-            { typeof(bool), "bool" },
-            { typeof(byte), "byte" },
-            { typeof(sbyte), "sbyte" },
-            { typeof(char), "char" },
-            { typeof(decimal), "decimal" },
-            { typeof(double), "double" },
-            { typeof(float), "float" },
-            { typeof(int), "int" },
-            { typeof(uint), "uint" },
-            { typeof(long), "long" },
-            { typeof(ulong), "ulong" },
-            { typeof(short), "short" },
-            { typeof(ushort), "ushort" },
-            { typeof(object), "object" },
-            { typeof(string), "string" },
-            { typeof(void), "void" }
-        };
-        return builtInTypes.TryGetValue(type, out var builtInName) ? builtInName : type.Name;
+        return type.FullName is string fullName && BuiltInTypeNames.TryGetValue(fullName, out var builtInName)
+            ? builtInName
+            : type.Name;
     }
+
+    private static readonly Dictionary<string, string> BuiltInTypeNames = new(StringComparer.Ordinal)
+    {
+        ["System.Boolean"] = "bool",
+        ["System.Byte"] = "byte",
+        ["System.SByte"] = "sbyte",
+        ["System.Char"] = "char",
+        ["System.Decimal"] = "decimal",
+        ["System.Double"] = "double",
+        ["System.Single"] = "float",
+        ["System.Int32"] = "int",
+        ["System.UInt32"] = "uint",
+        ["System.Int64"] = "long",
+        ["System.UInt64"] = "ulong",
+        ["System.Int16"] = "short",
+        ["System.UInt16"] = "ushort",
+        ["System.Object"] = "object",
+        ["System.String"] = "string",
+        ["System.Void"] = "void"
+    };
+
     private static string GetAccessModifier(MemberInfo member)
     {
         return member switch
@@ -377,21 +411,19 @@ public class MemberAnalysisService : IMemberAnalysisService
     }
     private static bool IsExtensionMethod(MethodInfo method)
     {
-        return method.IsStatic && 
-               method.GetCustomAttribute<System.Runtime.CompilerServices.ExtensionAttribute>() != null;
+        return method.IsStatic &&
+               method.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.ExtensionAttribute");
     }
     private static bool IsOverrideMethod(MethodBase method)
     {
-        if (method is MethodInfo methodInfo)
-        {
-            return methodInfo.GetBaseDefinition() != methodInfo;
-        }
-        return false;
+        if (method is not MethodInfo methodInfo) return false;
+        if (!methodInfo.IsVirtual) return false;
+        return (methodInfo.Attributes & MethodAttributes.NewSlot) == 0;
     }
     private static bool IsVolatileField(FieldInfo field)
     {
         var requiredModifiers = field.GetRequiredCustomModifiers();
-        return requiredModifiers.Any(m => m == typeof(System.Runtime.CompilerServices.IsVolatile));
+        return requiredModifiers.Any(m => m.FullName == "System.Runtime.CompilerServices.IsVolatile");
     }
     private static string BuildMethodSignature(MethodInfo method, ParameterDetails[] parameters, string[] genericParams)
     {

--- a/src/runtime/TypeAnalysisService.cs
+++ b/src/runtime/TypeAnalysisService.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Reflection;
-using System.Runtime.Loader;
 using Sherlock.MCP.Runtime.Inspection;
 using TypeAnalysisInfo = Sherlock.MCP.Runtime.Contracts.TypeAnalysis.TypeInfo;
 using TypeAnalysisHierarchy = Sherlock.MCP.Runtime.Contracts.TypeAnalysis.TypeHierarchy;

--- a/src/runtime/TypeAnalysisService.cs
+++ b/src/runtime/TypeAnalysisService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.Loader;
 using Sherlock.MCP.Runtime.Inspection;
@@ -12,9 +13,11 @@ using TypeAnalysisGenericVariance = Sherlock.MCP.Runtime.Contracts.TypeAnalysis.
 
 namespace Sherlock.MCP.Runtime;
 
-public class TypeAnalysisService : ITypeAnalysisService
+public class TypeAnalysisService : ITypeAnalysisService, IDisposable
 {
-    private readonly Dictionary<string, IAssemblyInspectionContext> _contexts = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, IAssemblyInspectionContext> _contexts
+        = new(StringComparer.OrdinalIgnoreCase);
+    private bool _disposed;
 
     public Assembly? LoadAssembly(string assemblyPath)
     {
@@ -26,14 +29,29 @@ public class TypeAnalysisService : ITypeAnalysisService
                 return existing.Assembly;
             }
 
-            var ctx = InspectionContextFactory.Create(assemblyPath);
-            _contexts[assemblyPath] = ctx;
-            return ctx.Assembly;
+            var created = InspectionContextFactory.Create(assemblyPath);
+            var stored = _contexts.GetOrAdd(assemblyPath, created);
+            if (!ReferenceEquals(stored, created))
+            {
+                created.Dispose();
+            }
+            return stored.Assembly;
         }
         catch
         {
             return null;
         }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        foreach (var ctx in _contexts.Values)
+        {
+            try { ctx.Dispose(); } catch { }
+        }
+        _contexts.Clear();
     }
 
     public TypeAnalysisInfo GetTypeInfo(Type type)
@@ -183,6 +201,16 @@ public class TypeAnalysisService : ITypeAnalysisService
         }
     }
 
+    private static bool InheritsFromDelegate(Type type)
+    {
+        for (var current = type.BaseType; current != null; current = current.BaseType)
+        {
+            if (current.FullName == "System.Delegate" || current.FullName == "System.MulticastDelegate")
+                return true;
+        }
+        return false;
+    }
+
     private static TypeAnalysisTypeKind GetTypeKind(Type type)
     {
         if (type.IsEnum) return TypeAnalysisTypeKind.Enum;
@@ -192,7 +220,7 @@ public class TypeAnalysisService : ITypeAnalysisService
         if (type.IsPointer) return TypeAnalysisTypeKind.Pointer;
         if (type.IsByRef) return TypeAnalysisTypeKind.ByRef;
         if (type.IsGenericParameter) return TypeAnalysisTypeKind.GenericParameter;
-        if (typeof(Delegate).IsAssignableFrom(type)) return TypeAnalysisTypeKind.Delegate;
+        if (InheritsFromDelegate(type)) return TypeAnalysisTypeKind.Delegate;
         if (type.IsClass) return TypeAnalysisTypeKind.Class;
         return TypeAnalysisTypeKind.Unknown;
     }

--- a/src/server/Shared/AssemblyLocator.cs
+++ b/src/server/Shared/AssemblyLocator.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+using Sherlock.MCP.Runtime.Inspection;
 
 namespace Sherlock.MCP.Server.Shared;
 
@@ -33,8 +33,8 @@ internal static class AssemblyLocator
       try
       {
          var assemblyPath = assemblyPaths.First();
-         var assembly = Assembly.LoadFrom(assemblyPath);
-         var types = assembly.GetExportedTypes();
+         using var ctx = InspectionContextFactory.Create(assemblyPath);
+         var types = ctx.Assembly.GetExportedTypes();
          var matchingType = types.FirstOrDefault(type =>
             type.Name.Equals(className, StringComparison.OrdinalIgnoreCase) ||
             type.FullName?.Equals(className, StringComparison.OrdinalIgnoreCase) == true);

--- a/src/server/Sherlock.MCP.Server.csproj
+++ b/src/server/Sherlock.MCP.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.7.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/server/Tools/MemberAnalysisTools.cs
+++ b/src/server/Tools/MemberAnalysisTools.cs
@@ -1,6 +1,7 @@
 using ModelContextProtocol.Server;
 using Sherlock.MCP.Runtime;
 using Sherlock.MCP.Runtime.Contracts.MemberAnalysis;
+using Sherlock.MCP.Runtime.Inspection;
 using Sherlock.MCP.Server.Middleware;
 using Sherlock.MCP.Server.Shared;
 using System.ComponentModel;
@@ -67,7 +68,8 @@ public static class MemberAnalysisTools
                 };
 
                 // Resolve type
-                var assembly = Assembly.LoadFrom(assemblyPath);
+                using var ctx = InspectionContextFactory.Create(assemblyPath);
+                var assembly = ctx.Assembly;
                 var type = assembly.GetType(typeName)
                     ?? assembly.GetExportedTypes()
                         .FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
@@ -168,7 +170,8 @@ public static class MemberAnalysisTools
         {
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
-            var asm = Assembly.LoadFrom(assemblyPath);
+            using var ctx = InspectionContextFactory.Create(assemblyPath);
+            var asm = ctx.Assembly;
             var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
             var type = asm.GetType(typeName, false, !caseSensitive)
                        ?? asm.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, comparison) || string.Equals(t.Name, typeName, comparison));
@@ -210,7 +213,8 @@ public static class MemberAnalysisTools
         {
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
-            var asm = Assembly.LoadFrom(assemblyPath);
+            using var ctx = InspectionContextFactory.Create(assemblyPath);
+            var asm = ctx.Assembly;
             var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
             var type = asm.GetType(typeName, false, !caseSensitive)
                        ?? asm.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, comparison) || string.Equals(t.Name, typeName, comparison));
@@ -288,7 +292,8 @@ public static class MemberAnalysisTools
                 };
 
                 // Resolve type
-                var assembly = Assembly.LoadFrom(assemblyPath);
+                using var ctx = InspectionContextFactory.Create(assemblyPath);
+                var assembly = ctx.Assembly;
                 var type = assembly.GetType(typeName)
                     ?? assembly.GetExportedTypes()
                         .FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
@@ -417,7 +422,8 @@ public static class MemberAnalysisTools
                 };
 
                 // Resolve type
-                var assembly = Assembly.LoadFrom(assemblyPath);
+                using var ctx = InspectionContextFactory.Create(assemblyPath);
+                var assembly = ctx.Assembly;
                 var type = assembly.GetType(typeName)
                     ?? assembly.GetExportedTypes()
                         .FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
@@ -531,7 +537,8 @@ public static class MemberAnalysisTools
                     SortOrder = sortOrder
                 };
 
-                var assembly = Assembly.LoadFrom(assemblyPath);
+                using var ctx = InspectionContextFactory.Create(assemblyPath);
+                var assembly = ctx.Assembly;
                 var type = assembly.GetType(typeName)
                     ?? assembly.GetExportedTypes()
                         .FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
@@ -646,7 +653,8 @@ public static class MemberAnalysisTools
                     SortOrder = sortOrder
                 };
 
-                var assembly = Assembly.LoadFrom(assemblyPath);
+                using var ctx = InspectionContextFactory.Create(assemblyPath);
+                var assembly = ctx.Assembly;
                 var type = assembly.GetType(typeName)
                     ?? assembly.GetExportedTypes()
                         .FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
@@ -747,7 +755,8 @@ public static class MemberAnalysisTools
                     IncludeInstance = includeInstance
                 };
 
-                var assembly = Assembly.LoadFrom(assemblyPath);
+                using var ctx = InspectionContextFactory.Create(assemblyPath);
+                var assembly = ctx.Assembly;
                 var type = assembly.GetType(typeName)
                     ?? assembly.GetExportedTypes()
                         .FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)

--- a/src/server/Tools/MemberAnalysisTools.cs
+++ b/src/server/Tools/MemberAnalysisTools.cs
@@ -173,7 +173,7 @@ public static class MemberAnalysisTools
             using var ctx = InspectionContextFactory.Create(assemblyPath);
             var asm = ctx.Assembly;
             var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
-            var type = asm.GetType(typeName, false, !caseSensitive)
+            var type = asm.GetType(typeName)
                        ?? asm.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, comparison) || string.Equals(t.Name, typeName, comparison));
             if (type == null)
                 return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
@@ -216,7 +216,7 @@ public static class MemberAnalysisTools
             using var ctx = InspectionContextFactory.Create(assemblyPath);
             var asm = ctx.Assembly;
             var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
-            var type = asm.GetType(typeName, false, !caseSensitive)
+            var type = asm.GetType(typeName)
                        ?? asm.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, comparison) || string.Equals(t.Name, typeName, comparison));
             if (type == null)
                 return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");

--- a/src/server/Tools/ReflectionTools.cs
+++ b/src/server/Tools/ReflectionTools.cs
@@ -100,6 +100,12 @@ public static class ReflectionTools
         }
     }
 
+    private static object? SafeRawDefault(ParameterInfo p)
+    {
+        try { return p.RawDefaultValue; }
+        catch { return null; }
+    }
+
     private static List<dynamic> CollectAllMembers(
         ConstructorInfo[] constructors, MethodInfo[] methods,
         PropertyInfo[] properties, FieldInfo[] fields,
@@ -434,7 +440,7 @@ public static class ReflectionTools
                         type = p.ParameterType.FullName,
                         position = p.Position,
                         hasDefaultValue = p.HasDefaultValue,
-                        defaultValue = p.HasDefaultValue ? p.DefaultValue?.ToString() : null,
+                        defaultValue = p.HasDefaultValue ? SafeRawDefault(p)?.ToString() : null,
                         isIn = p.IsIn,
                         isOut = p.IsOut,
                         isParams = p.CustomAttributes.Any(a => a.AttributeType.FullName == "System.ParamArrayAttribute")

--- a/src/server/Tools/ReflectionTools.cs
+++ b/src/server/Tools/ReflectionTools.cs
@@ -437,11 +437,11 @@ public static class ReflectionTools
                         defaultValue = p.HasDefaultValue ? p.DefaultValue?.ToString() : null,
                         isIn = p.IsIn,
                         isOut = p.IsOut,
-                        isParams = p.GetCustomAttributes(typeof(ParamArrayAttribute), false).Length > 0
+                        isParams = p.CustomAttributes.Any(a => a.AttributeType.FullName == "System.ParamArrayAttribute")
                     }).ToArray(),
-                    attributes = method.GetCustomAttributes().Select(attr => new
+                    attributes = method.GetCustomAttributesData().Select(attr => new
                     {
-                        type = attr.GetType().FullName,
+                        type = attr.AttributeType.FullName,
                         toString = attr.ToString()
                     }).ToArray()
                 }).ToArray()

--- a/src/server/Tools/XmlDocTools.cs
+++ b/src/server/Tools/XmlDocTools.cs
@@ -1,5 +1,6 @@
 using ModelContextProtocol.Server;
 using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Inspection;
 using Sherlock.MCP.Server.Shared;
 using System.ComponentModel;
 using System.Reflection;
@@ -20,7 +21,8 @@ public static class XmlDocTools
         try
         {
             if (!File.Exists(assemblyPath)) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
-            var asm = Assembly.LoadFrom(assemblyPath);
+            using var ctx = InspectionContextFactory.Create(assemblyPath);
+            var asm = ctx.Assembly;
             var type = asm.GetType(typeName, false, !caseSensitive)
                     ?? asm.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) || string.Equals(t.Name, typeName, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase));
             if (type == null) return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
@@ -47,7 +49,8 @@ public static class XmlDocTools
         try
         {
             if (!File.Exists(assemblyPath)) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
-            var asm = Assembly.LoadFrom(assemblyPath);
+            using var ctx = InspectionContextFactory.Create(assemblyPath);
+            var asm = ctx.Assembly;
             var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
             var type = asm.GetType(typeName, false, !caseSensitive)
                     ?? asm.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, comparison) || string.Equals(t.Name, typeName, comparison));

--- a/src/server/Tools/XmlDocTools.cs
+++ b/src/server/Tools/XmlDocTools.cs
@@ -23,8 +23,9 @@ public static class XmlDocTools
             if (!File.Exists(assemblyPath)) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
             using var ctx = InspectionContextFactory.Create(assemblyPath);
             var asm = ctx.Assembly;
-            var type = asm.GetType(typeName, false, !caseSensitive)
-                    ?? asm.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) || string.Equals(t.Name, typeName, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase));
+            var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+            var type = asm.GetType(typeName)
+                    ?? asm.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, comparison) || string.Equals(t.Name, typeName, comparison));
             if (type == null) return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
             var info = xmlDocs.GetXmlDocsForType(type);
             return info == null
@@ -52,7 +53,7 @@ public static class XmlDocTools
             using var ctx = InspectionContextFactory.Create(assemblyPath);
             var asm = ctx.Assembly;
             var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
-            var type = asm.GetType(typeName, false, !caseSensitive)
+            var type = asm.GetType(typeName)
                     ?? asm.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, comparison) || string.Equals(t.Name, typeName, comparison));
             if (type == null) return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
             var member = (MemberInfo?) type.GetMembers(BindingFlags.Public|BindingFlags.NonPublic|BindingFlags.Instance|BindingFlags.Static)

--- a/src/unit-tests/TransitiveAssemblyResolutionTests.cs
+++ b/src/unit-tests/TransitiveAssemblyResolutionTests.cs
@@ -96,7 +96,7 @@ public class TransitiveAssemblyResolutionTests
     }
 
     [Fact]
-    public void MetadataOnlyContext_ReadsAttributeData_WithoutResolvingAttributeDependencies()
+    public void MetadataOnlyContext_ReadsCustomAttributeData_ForExternallyDefinedAttribute()
     {
         var testAssemblyPath = Assembly.GetExecutingAssembly().Location;
 
@@ -111,7 +111,7 @@ public class TransitiveAssemblyResolutionTests
     }
 
     [Fact]
-    public void MetadataOnlyContext_ReadsExternalAttributeUsage_WithoutThrowing()
+    public void MetadataOnlyContext_ProjectsMemberAttributesToContractRecords()
     {
         var testAssemblyPath = Assembly.GetExecutingAssembly().Location;
 

--- a/src/unit-tests/TransitiveAssemblyResolutionTests.cs
+++ b/src/unit-tests/TransitiveAssemblyResolutionTests.cs
@@ -94,4 +94,34 @@ public class TransitiveAssemblyResolutionTests
 
         Assert.True(members.Length > 0);
     }
+
+    [Fact]
+    public void MetadataOnlyContext_ReadsAttributeData_WithoutResolvingAttributeDependencies()
+    {
+        var testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+        using var ctx = new MetadataOnlyInspectionContext(testAssemblyPath);
+        var testType = ctx.GetTypes().First(t => t.Name == nameof(TransitiveAssemblyResolutionTests));
+        var factMethod = testType.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .First(m => m.Name == nameof(MetadataOnlyContext_Loads_Assembly_Successfully));
+
+        var attrs = factMethod.GetCustomAttributesData();
+
+        Assert.Contains(attrs, a => a.AttributeType.FullName == "Xunit.FactAttribute");
+    }
+
+    [Fact]
+    public void MetadataOnlyContext_ReadsExternalAttributeUsage_WithoutThrowing()
+    {
+        var testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+        using var ctx = new MetadataOnlyInspectionContext(testAssemblyPath);
+        var testType = ctx.GetTypes().First(t => t.Name == nameof(TransitiveAssemblyResolutionTests));
+        var members = testType.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+        var infos = members.SelectMany(Sherlock.MCP.Runtime.AttributeUtils.FromMember).ToArray();
+
+        Assert.NotEmpty(infos);
+        Assert.All(infos, info => Assert.False(string.IsNullOrEmpty(info.AttributeType)));
+    }
 }


### PR DESCRIPTION
## Summary

Migrates the default inspection path from `Assembly.LoadFrom` (default `AssemblyLoadContext`) to `System.Reflection.MetadataLoadContext` so inspection tools no longer fail mid-session with `Could not load file or assembly` when an inspected type references an attribute whose dependencies are absent on disk.

- New `MetadataResolverFactory` builds a `PathAssemblyResolver` from the target DLL, its sibling DLLs, and the runtime directory.
- `MetadataOnlyInspectionContext` now owns a `MetadataLoadContext` and disposes it.
- Eleven direct `Assembly.LoadFrom` call sites in the server tools (`MemberAnalysisTools`, `XmlDocTools`, `AssemblyLocator`) now route through `InspectionContextFactory.Create`.
- Six MLC-incompatible reflection patterns patched: `GetCustomAttribute<T>()` → `CustomAttributeData`; `typeof()` comparisons → `FullName` string checks; `GetBaseDefinition()` → `MethodAttributes.NewSlot` check; `DefaultValue` → `RawDefaultValue`; dropped `ignoreCase:true` on `Assembly.GetType`.
- `TypeAnalysisService` and `MemberAnalysisService` now cache inspection contexts in `ConcurrentDictionary` and implement `IDisposable` so the DI container disposes the underlying MLC instances at host shutdown.
- `IsolatedRuntimeInspectionContext` / `DependencyResolvingLoadContext` (the `forceRuntimeLoad: true` path) is untouched — preserved for any future execution-required scenarios.
- Version bumped to 2.7.1 (patch) with CHANGELOG entry.

Closes #19.

## Test plan

- [x] `dotnet build src/Sherlock.MCP.sln` — clean (only pre-existing warnings).
- [x] `dotnet test src/Sherlock.MCP.sln -f net8.0` — 35/35 passing.
- [x] `dotnet test src/Sherlock.MCP.sln -f net10.0` — 35/35 passing.
- [x] `TransitiveAssemblyResolutionTests` (exercises `IsolatedRuntimeInspectionContext`) still green.
- [x] Two new tests added verifying `MetadataOnlyInspectionContext` reads attribute data end-to-end under MLC.
- [ ] End-to-end manual validation against a real consumer scenario with a deleted transitive DLL — to be validated post-merge on a downstream project.