### PR TITLE
fix(runtime): project Type attribute args to JSON-safe TypeRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.2] - 2026-04-18
+
+### Fixed
+
+- Attribute dumping no longer crashes JSON serialization when an attribute argument is a `typeof(...)` value. `AttributeUtils` now projects `Type` arguments (including `Type[]`) to a serializable `TypeRef { FullName, AssemblyName }` contract at extraction time, so consumers of `get_member_attributes`, `get_type_methods`, and related tools can serialize results without hitting `Serialization and deserialization of 'System.RuntimeType' instances is not supported`. (#20)
+
 ## [2.7.1] - 2026-04-17
 
 ### Fixed
@@ -33,5 +39,6 @@ This is the baseline release for conventional commits adoption. Prior versions w
 
 Versions prior to 2.7.0 were not tracked with conventional commits. This changelog begins with 2.7.0 as the baseline.
 
+[2.7.2]: https://github.com/jcucci/dotnet-sherlock-mcp/releases/tag/v2.7.2
 [2.7.1]: https://github.com/jcucci/dotnet-sherlock-mcp/releases/tag/v2.7.1
 [2.7.0]: https://github.com/jcucci/dotnet-sherlock-mcp/releases/tag/v2.7.0

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/jcucci/dotnet-sherlock-mcp",
     "source": "github"
   },
-  "version": "2.7.1",
+  "version": "2.7.2",
   "packages": [
     {
       "registryType": "nuget",
       "identifier": "Sherlock.MCP.Server",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/runtime/AttributeUtils.cs
+++ b/src/runtime/AttributeUtils.cs
@@ -36,13 +36,13 @@ public static class AttributeUtils
     public static AttributeInfo Convert(CustomAttributeData attributeData)
     {
         var constructorArgs = attributeData.ConstructorArguments
-            .Select(arg => arg.Value)
+            .Select(arg => ProjectValue(arg.Value))
             .ToArray();
 
         var namedArgs = attributeData.NamedArguments
             .ToDictionary(
                 arg => arg.MemberName,
-                arg => arg.TypedValue.Value
+                arg => ProjectValue(arg.TypedValue.Value)
             );
 
         var attributeType = attributeData.AttributeType;
@@ -56,6 +56,15 @@ public static class AttributeUtils
             ValidOn: validOn
         );
     }
+
+    private static object? ProjectValue(object? raw) => raw switch
+    {
+        null => null,
+        Type t => new TypeRef(t.FullName ?? t.Name, t.Assembly.GetName().Name),
+        IReadOnlyCollection<CustomAttributeTypedArgument> elems
+            => elems.Select(e => ProjectValue(e.Value)).ToArray(),
+        _ => raw
+    };
 
     private static (bool AllowMultiple, AttributeTargets ValidOn) ReadAttributeUsage(Type attributeType)
     {

--- a/src/runtime/Contracts/TypeAnalysis/TypeRef.cs
+++ b/src/runtime/Contracts/TypeAnalysis/TypeRef.cs
@@ -1,0 +1,3 @@
+namespace Sherlock.MCP.Runtime.Contracts.TypeAnalysis;
+
+public record TypeRef(string FullName, string? AssemblyName);

--- a/src/server/Sherlock.MCP.Server.csproj
+++ b/src/server/Sherlock.MCP.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.7.1</Version>
+    <Version>2.7.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/unit-tests/AttributeUtilsTests.cs
+++ b/src/unit-tests/AttributeUtilsTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Contracts.TypeAnalysis;
+
+namespace Sherlock.MCP.Tests;
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class TypeCtorAttribute : Attribute
+{
+    public TypeCtorAttribute(Type target) => Target = target;
+    public Type Target { get; }
+    public Type? Alternate { get; set; }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class TypeArrayCtorAttribute : Attribute
+{
+    public TypeArrayCtorAttribute(Type[] targets) => Targets = targets;
+    public Type[] Targets { get; }
+}
+
+internal class AttributeUtilsTestSubject
+{
+    [TypeCtor(typeof(int))]
+    public void CtorTypeArgMethod() { }
+
+    [TypeCtor(typeof(string), Alternate = typeof(Guid))]
+    public void NamedTypeArgMethod() { }
+
+    [TypeArrayCtor(new[] { typeof(int), typeof(string) })]
+    public void TypeArrayArgMethod() { }
+}
+
+public class AttributeUtilsTests
+{
+    [Fact]
+    public void Convert_ProjectsCtorTypeArg_ToTypeRef_AndSerializes()
+    {
+        var method = typeof(AttributeUtilsTestSubject).GetMethod(nameof(AttributeUtilsTestSubject.CtorTypeArgMethod))!;
+
+        var attrs = AttributeUtils.FromMember(method);
+        var attr = Assert.Single(attrs, a => a.AttributeType == typeof(TypeCtorAttribute).FullName);
+        var projected = Assert.IsType<TypeRef>(attr.ConstructorArguments[0]);
+        Assert.Equal(typeof(int).FullName, projected.FullName);
+        Assert.Equal(typeof(int).Assembly.GetName().Name, projected.AssemblyName);
+
+        var json = JsonSerializer.Serialize(attrs);
+        Assert.Contains(typeof(int).FullName!, json);
+    }
+
+    [Fact]
+    public void Convert_ProjectsNamedTypeArg_ToTypeRef_AndSerializes()
+    {
+        var method = typeof(AttributeUtilsTestSubject).GetMethod(nameof(AttributeUtilsTestSubject.NamedTypeArgMethod))!;
+
+        var attrs = AttributeUtils.FromMember(method);
+        var attr = Assert.Single(attrs, a => a.AttributeType == typeof(TypeCtorAttribute).FullName);
+        Assert.True(attr.NamedArguments.ContainsKey("Alternate"));
+        var projected = Assert.IsType<TypeRef>(attr.NamedArguments["Alternate"]);
+        Assert.Equal(typeof(Guid).FullName, projected.FullName);
+
+        var json = JsonSerializer.Serialize(attrs);
+        Assert.Contains(typeof(Guid).FullName!, json);
+    }
+
+    [Fact]
+    public void Convert_ProjectsTypeArrayArg_ToTypeRefArray_AndSerializes()
+    {
+        var method = typeof(AttributeUtilsTestSubject).GetMethod(nameof(AttributeUtilsTestSubject.TypeArrayArgMethod))!;
+
+        var attrs = AttributeUtils.FromMember(method);
+        var attr = Assert.Single(attrs, a => a.AttributeType == typeof(TypeArrayCtorAttribute).FullName);
+        var arr = Assert.IsType<object?[]>(attr.ConstructorArguments[0]);
+        Assert.Equal(2, arr.Length);
+        var first = Assert.IsType<TypeRef>(arr[0]);
+        var second = Assert.IsType<TypeRef>(arr[1]);
+        Assert.Equal(typeof(int).FullName, first.FullName);
+        Assert.Equal(typeof(string).FullName, second.FullName);
+
+        var json = JsonSerializer.Serialize(attrs);
+        Assert.Contains(typeof(int).FullName!, json);
+        Assert.Contains(typeof(string).FullName!, json);
+    }
+}


### PR DESCRIPTION
## Summary

- `AttributeUtils.Convert` now projects `Type` values from `CustomAttributeData` into a new `TypeRef(FullName, AssemblyName)` contract so `System.Text.Json` can serialize them. The previous raw `RuntimeType` leaked straight into `AttributeInfo` and broke any tool that dumped attributes for a member decorated with e.g. `[JsonConverter(typeof(X))]` — consumer-reported as a session-blocker.
- Recurses through `IReadOnlyCollection<CustomAttributeTypedArgument>` to cover `Type[]` arguments.
- No change to `AttributeInfo` shape; all 10 existing callers see the same record, only the embedded values are now JSON-safe.

Closes #20.

## Test plan

- [x] `dotnet build src/Sherlock.MCP.sln` — clean (pre-existing warnings only)
- [x] `dotnet test src/Sherlock.MCP.sln` — 38/38 passing on net8.0 and net10.0 (net9.0 skipped locally; CI runs it)
- [x] 3 new `AttributeUtilsTests` facts round-trip via `JsonSerializer.Serialize`:
  - ctor `Type` arg → `TypeRef`
  - named `Type` property → `TypeRef`
  - `Type[]` arg → `object?[]` of `TypeRef`