### PR TITLE
feat(tools): add projection (summary|full) to listings, default summary

### DIFF
--- a/src/server/Tools/MemberAnalysisTools.cs
+++ b/src/server/Tools/MemberAnalysisTools.cs
@@ -51,6 +51,14 @@ public static class MemberAnalysisTools
             if (normalizedProjection != "summary" && normalizedProjection != "full")
                 return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
 
+            // Salt seed: identifies the result set (filters + ordering). MUST exclude pagination
+            // params (continuationToken, skip, take, maxItems) and rendering params (projection)
+            // so a token minted on page 1 still validates on page 2.
+            var saltSeed = CacheKeyHelper.Build(
+                "member.methods.salt",
+                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder);
+
             var cacheKey = CacheKeyHelper.Build(
                 "member.methods",
                 assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
@@ -88,7 +96,7 @@ public static class MemberAnalysisTools
                 var defaultPageSize = runtimeOptions.GetMaxItemsForTool("GetTypeMethods");
                 var pageSize = Math.Max(1, maxItems ?? take ?? defaultPageSize);
                 var offset = 0;
-                string salt = TokenHelper.MakeSalt(cacheKey);
+                string salt = TokenHelper.MakeSalt(saltSeed);
                 if (!string.IsNullOrWhiteSpace(continuationToken))
                 {
                     if (!TokenHelper.TryParse(continuationToken!, out offset, out var parsedSalt) || parsedSalt != salt)
@@ -282,6 +290,11 @@ public static class MemberAnalysisTools
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
+            var saltSeed = CacheKeyHelper.Build(
+                "member.properties.salt",
+                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder);
+
             var cacheKey = CacheKeyHelper.Build(
                 "member.properties",
                 assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
@@ -319,7 +332,7 @@ public static class MemberAnalysisTools
                 var defaultPageSize = runtimeOptions.GetMaxItemsForTool("GetTypeProperties");
                 var pageSize = Math.Max(1, maxItems ?? take ?? defaultPageSize);
                 var offset = 0;
-                string salt = TokenHelper.MakeSalt(cacheKey);
+                string salt = TokenHelper.MakeSalt(saltSeed);
                 if (!string.IsNullOrWhiteSpace(continuationToken))
                 {
                     if (!TokenHelper.TryParse(continuationToken!, out offset, out var parsedSalt) || parsedSalt != salt)
@@ -412,6 +425,11 @@ public static class MemberAnalysisTools
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
+            var saltSeed = CacheKeyHelper.Build(
+                "member.fields.salt",
+                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder);
+
             var cacheKey = CacheKeyHelper.Build(
                 "member.fields",
                 assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
@@ -449,7 +467,7 @@ public static class MemberAnalysisTools
                 var defaultPageSize = runtimeOptions.GetMaxItemsForTool("GetTypeFields");
                 var pageSize = Math.Max(1, maxItems ?? take ?? defaultPageSize);
                 var offset = 0;
-                string salt = TokenHelper.MakeSalt(cacheKey);
+                string salt = TokenHelper.MakeSalt(saltSeed);
                 if (!string.IsNullOrWhiteSpace(continuationToken))
                 {
                     if (!TokenHelper.TryParse(continuationToken!, out offset, out var parsedSalt) || parsedSalt != salt)
@@ -529,6 +547,11 @@ public static class MemberAnalysisTools
         {
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
+            var saltSeed = CacheKeyHelper.Build(
+                "member.events.salt",
+                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder);
+
             var cacheKey = CacheKeyHelper.Build(
                 "member.events",
                 assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
@@ -563,7 +586,7 @@ public static class MemberAnalysisTools
                 var defaultPageSize = runtimeOptions.GetMaxItemsForTool("GetTypeEvents");
                 var pageSize = Math.Max(1, maxItems ?? take ?? defaultPageSize);
                 var offset = 0;
-                string salt = TokenHelper.MakeSalt(cacheKey);
+                string salt = TokenHelper.MakeSalt(saltSeed);
                 if (!string.IsNullOrWhiteSpace(continuationToken))
                 {
                     if (!TokenHelper.TryParse(continuationToken!, out offset, out var parsedSalt) || parsedSalt != salt)
@@ -645,6 +668,11 @@ public static class MemberAnalysisTools
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
+            var saltSeed = CacheKeyHelper.Build(
+                "member.constructors.salt",
+                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder);
+
             var cacheKey = CacheKeyHelper.Build(
                 "member.constructors",
                 assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
@@ -679,7 +707,7 @@ public static class MemberAnalysisTools
                 var defaultPageSize = runtimeOptions.GetMaxItemsForTool("GetTypeConstructors");
                 var pageSize = Math.Max(1, maxItems ?? take ?? defaultPageSize);
                 var offset = 0;
-                string salt = TokenHelper.MakeSalt(cacheKey);
+                string salt = TokenHelper.MakeSalt(saltSeed);
                 if (!string.IsNullOrWhiteSpace(continuationToken))
                 {
                     if (!TokenHelper.TryParse(continuationToken!, out offset, out var parsedSalt) || parsedSalt != salt)

--- a/src/server/Tools/MemberAnalysisTools.cs
+++ b/src/server/Tools/MemberAnalysisTools.cs
@@ -19,7 +19,7 @@ public static class MemberAnalysisTools
     };
 
     [McpServerTool]
-    [Description("Gets methods from a type with filtering and pagination. Large types may have 100+ methods - use nameContains filter or maxItems=25 for efficiency. Prefer over GetAllTypeMembers when only methods needed.")]
+    [Description("Gets methods from a type with filtering and pagination. Returns a lean summary ({ name, signature }) by default - the signature already encodes return type, parameters, and modifiers in C# form. Pass projection='full' when you need structured fields (parameters[], attributes, returnType, isStatic/Virtual/Abstract/..., genericTypeParameters); prefer AnalyzeMethod for one method. Large types may have 100+ methods - use nameContains filter or maxItems=25 for efficiency.")]
     public static string GetTypeMethods(
         IMemberAnalysisService memberAnalysisService,
         ToolMiddleware middleware,
@@ -39,17 +39,22 @@ public static class MemberAnalysisTools
         [Description("Sort order: asc|desc (default: asc)")] string sortOrder = "asc",
         [Description("Maximum items to return (overrides take)")] int? maxItems = null,
         [Description("Continuation token for paging")] string? continuationToken = null,
-        [Description("Bypass cache for this request")] bool noCache = false)
+        [Description("Bypass cache for this request")] bool noCache = false,
+        [Description("Response shape. 'summary' (default, token-lean): { name, signature } only - the C# signature already carries return type, parameters, and modifiers. 'full': adds parameters[], attributes, returnType, and all modifier booleans - use only when you need structured access to those fields.")] string projection = "summary")
     {
         try
         {
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
+            var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
+            if (normalizedProjection != "summary" && normalizedProjection != "full")
+                return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
+
             var cacheKey = CacheKeyHelper.Build(
                 "member.methods",
                 assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
-                caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder, maxItems, continuationToken, skip, take);
+                caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder, maxItems, continuationToken, skip, take, normalizedProjection);
 
             return middleware.Execute(cacheKey, () =>
             {
@@ -104,40 +109,47 @@ public static class MemberAnalysisTools
                     nextToken = TokenHelper.Make(nextOffset, salt);
                 }
 
-                var methods = pageItems.Select(m => new
-                {
-                    name = m.Name,
-                    signature = m.Signature,
-                    returnType = m.ReturnTypeName,
-                    accessModifier = m.AccessModifier,
-                    isStatic = m.IsStatic,
-                    isVirtual = m.IsVirtual,
-                    isAbstract = m.IsAbstract,
-                    isSealed = m.IsSealed,
-                    isOverride = m.IsOverride,
-                    isOperator = m.IsOperator,
-                    isExtensionMethod = m.IsExtensionMethod,
-                    genericTypeParameters = m.GenericTypeParameters,
-                    attributes = m.CustomAttributes,
-                    parameters = m.Parameters.Select(p => new
+                object methods = normalizedProjection == "summary"
+                    ? pageItems.Select(m => new
                     {
-                        name = p.Name,
-                        typeName = p.TypeName,
-                        defaultValue = p.DefaultValue,
-                        isOptional = p.IsOptional,
-                        isOut = p.IsOut,
-                        isRef = p.IsRef,
-                        isIn = p.IsIn,
-                        isParams = p.IsParams,
-                        attributes = p.CustomAttributes
+                        name = m.Name,
+                        signature = m.Signature
                     }).ToArray()
-                }).ToArray();
+                    : pageItems.Select(m => new
+                    {
+                        name = m.Name,
+                        signature = m.Signature,
+                        returnType = m.ReturnTypeName,
+                        accessModifier = m.AccessModifier,
+                        isStatic = m.IsStatic,
+                        isVirtual = m.IsVirtual,
+                        isAbstract = m.IsAbstract,
+                        isSealed = m.IsSealed,
+                        isOverride = m.IsOverride,
+                        isOperator = m.IsOperator,
+                        isExtensionMethod = m.IsExtensionMethod,
+                        genericTypeParameters = m.GenericTypeParameters,
+                        attributes = m.CustomAttributes,
+                        parameters = m.Parameters.Select(p => new
+                        {
+                            name = p.Name,
+                            typeName = p.TypeName,
+                            defaultValue = p.DefaultValue,
+                            isOptional = p.IsOptional,
+                            isOut = p.IsOut,
+                            isRef = p.IsRef,
+                            isIn = p.IsIn,
+                            isParams = p.IsParams,
+                            attributes = p.CustomAttributes
+                        }).ToArray()
+                    }).ToArray();
 
                 var methodsJson = JsonSerializer.Serialize(methods, SerializerOptions);
                 var result = new
                 {
                     typeName,
                     assemblyPath,
+                    projection = normalizedProjection,
                     total = all.Length,
                     count = pageItems.Length,
                     nextToken,

--- a/src/server/Tools/TypeAnalysisTools.cs
+++ b/src/server/Tools/TypeAnalysisTools.cs
@@ -13,18 +13,23 @@ public static class TypeAnalysisTools
     private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
 
     [McpServerTool]
-    [Description("Lists public types from an assembly with basic metadata. Returns totalTypeCount for pagination planning. Use maxItems=25 for large assemblies. Follow with GetTypeInfo for detailed analysis of specific types.")]
+    [Description("Lists public types from an assembly. Returns a lean summary ({ FullName, Namespace, Kind }) by default - use this to browse or search large assemblies. Pass projection='full' when you need attributes, inheritance, interfaces, generic params, and nested types; prefer GetTypeInfo for a single type instead. Returns totalTypeCount for pagination planning; use maxItems=25 for very large assemblies.")]
     public static string GetTypesFromAssembly(
         ITypeAnalysisService typeAnalysis,
         [Description("Path to the .NET assembly file (.dll or .exe)")] string assemblyPath,
         [Description("Maximum number of types to return (default: 50)")] int? maxItems = null,
         [Description("Items to skip (paging)")] int? skip = null,
-        [Description("Continuation token for paging")] string? continuationToken = null)
+        [Description("Continuation token for paging")] string? continuationToken = null,
+        [Description("Response shape. 'summary' (default, token-lean): { FullName, Namespace, Kind } only - use for browsing/searching. 'full': adds attributes, base type, interfaces, generic params, nested types - use only when you need those fields on every item.")] string projection = "summary")
     {
         try
         {
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
+
+            var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
+            if (normalizedProjection != "summary" && normalizedProjection != "full")
+                return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
 
             var allTypes = typeAnalysis.GetTypesFromAssembly(assemblyPath);
 
@@ -46,17 +51,22 @@ public static class TypeAnalysisTools
                 offset = skip.Value;
             }
 
-            var types = allTypes.Skip(offset).Take(pageSize).ToArray();
+            var pageTypes = allTypes.Skip(offset).Take(pageSize).ToArray();
             string? nextToken = null;
-            var nextOffset = offset + types.Length;
+            var nextOffset = offset + pageTypes.Length;
             if (nextOffset < allTypes.Length)
                 nextToken = TokenHelper.Make(nextOffset, salt);
+
+            object types = normalizedProjection == "summary"
+                ? pageTypes.Select(t => new { t.FullName, t.Namespace, t.Kind }).ToArray()
+                : pageTypes;
 
             var result = new
             {
                 assemblyPath,
+                projection = normalizedProjection,
                 totalTypeCount = allTypes.Length,
-                returnedTypeCount = types.Length,
+                returnedTypeCount = pageTypes.Length,
                 nextToken,
                 types
             };

--- a/src/unit-tests/PaginationTests.cs
+++ b/src/unit-tests/PaginationTests.cs
@@ -220,6 +220,59 @@ public class PaginationTests
     }
 
     [Fact]
+    public void GetTypeMethods_ContinuationToken_RoundTripsToNextPage()
+    {
+        var typeName = typeof(TestSampleClass).FullName!;
+
+        var page1 = MemberAnalysisTools.GetTypeMethods(
+            _memberAnalysisService, _middleware, _runtimeOptions,
+            _testAssemblyPath, typeName, maxItems: 1, noCache: true);
+
+        Assert.DoesNotContain("\"error\"", page1);
+        var page1Doc = JsonDocument.Parse(page1);
+        var page1Data = page1Doc.RootElement.GetProperty("data");
+        Assert.True(page1Data.GetProperty("total").GetInt32() > 1, "Need >1 method on TestSampleClass for round-trip test");
+
+        var nextToken = page1Data.GetProperty("nextToken").GetString();
+        Assert.False(string.IsNullOrEmpty(nextToken), "Page 1 should mint a nextToken when more pages remain");
+
+        var page2 = MemberAnalysisTools.GetTypeMethods(
+            _memberAnalysisService, _middleware, _runtimeOptions,
+            _testAssemblyPath, typeName, maxItems: 1, continuationToken: nextToken, noCache: true);
+
+        Assert.DoesNotContain("InvalidContinuationToken", page2);
+        Assert.DoesNotContain("\"error\"", page2);
+        var page2Data = JsonDocument.Parse(page2).RootElement.GetProperty("data");
+        Assert.Equal(1, page2Data.GetProperty("count").GetInt32());
+    }
+
+    [Fact]
+    public void GetTypeProperties_ContinuationToken_RoundTripsToNextPage()
+    {
+        var typeName = typeof(TestSampleClass).FullName!;
+
+        var page1 = MemberAnalysisTools.GetTypeProperties(
+            _memberAnalysisService, _middleware, _runtimeOptions,
+            _testAssemblyPath, typeName, includeNonPublic: true, maxItems: 1, noCache: true);
+
+        Assert.DoesNotContain("\"error\"", page1);
+        var page1Data = JsonDocument.Parse(page1).RootElement.GetProperty("data");
+        Assert.True(page1Data.GetProperty("total").GetInt32() > 1, "Need >1 property on TestSampleClass for round-trip test");
+
+        var nextToken = page1Data.GetProperty("nextToken").GetString();
+        Assert.False(string.IsNullOrEmpty(nextToken), "Page 1 should mint a nextToken when more pages remain");
+
+        var page2 = MemberAnalysisTools.GetTypeProperties(
+            _memberAnalysisService, _middleware, _runtimeOptions,
+            _testAssemblyPath, typeName, includeNonPublic: true, maxItems: 1, continuationToken: nextToken, noCache: true);
+
+        Assert.DoesNotContain("InvalidContinuationToken", page2);
+        Assert.DoesNotContain("\"error\"", page2);
+        var page2Data = JsonDocument.Parse(page2).RootElement.GetProperty("data");
+        Assert.Equal(1, page2Data.GetProperty("count").GetInt32());
+    }
+
+    [Fact]
     public void GetTypeMethods_InvalidProjection_ReturnsError()
     {
         var typeName = typeof(TestSampleClass).FullName!;

--- a/src/unit-tests/PaginationTests.cs
+++ b/src/unit-tests/PaginationTests.cs
@@ -116,6 +116,122 @@ public class PaginationTests
     }
 
     [Fact]
+    public void GetTypesFromAssembly_DefaultProjection_IsSummary()
+    {
+        var result = TypeAnalysisTools.GetTypesFromAssembly(_typeAnalysisService, _testAssemblyPath, maxItems: 3);
+
+        Assert.DoesNotContain("\"error\"", result);
+        var jsonDoc = JsonDocument.Parse(result);
+        var data = jsonDoc.RootElement.GetProperty("data");
+
+        Assert.Equal("summary", data.GetProperty("projection").GetString());
+
+        var types = data.GetProperty("types");
+        Assert.True(types.GetArrayLength() > 0, "Expected at least one type in the page");
+        var first = types[0];
+
+        Assert.True(first.TryGetProperty("FullName", out _), "Summary type should have FullName");
+        Assert.True(first.TryGetProperty("Namespace", out _), "Summary type should have Namespace");
+        Assert.True(first.TryGetProperty("Kind", out _), "Summary type should have Kind");
+
+        Assert.False(first.TryGetProperty("Attributes", out _), "Summary type should NOT include Attributes");
+        Assert.False(first.TryGetProperty("Interfaces", out _), "Summary type should NOT include Interfaces");
+        Assert.False(first.TryGetProperty("GenericParameters", out _), "Summary type should NOT include GenericParameters");
+        Assert.False(first.TryGetProperty("NestedTypes", out _), "Summary type should NOT include NestedTypes");
+    }
+
+    [Fact]
+    public void GetTypesFromAssembly_FullProjection_IncludesHeavyFields()
+    {
+        var result = TypeAnalysisTools.GetTypesFromAssembly(_typeAnalysisService, _testAssemblyPath, maxItems: 3, projection: "full");
+
+        Assert.DoesNotContain("\"error\"", result);
+        var jsonDoc = JsonDocument.Parse(result);
+        var data = jsonDoc.RootElement.GetProperty("data");
+
+        Assert.Equal("full", data.GetProperty("projection").GetString());
+
+        var types = data.GetProperty("types");
+        Assert.True(types.GetArrayLength() > 0, "Expected at least one type in the page");
+        var first = types[0];
+
+        Assert.True(first.TryGetProperty("Attributes", out _), "Full type should include Attributes");
+        Assert.True(first.TryGetProperty("Interfaces", out _), "Full type should include Interfaces");
+        Assert.True(first.TryGetProperty("GenericParameters", out _), "Full type should include GenericParameters");
+    }
+
+    [Fact]
+    public void GetTypesFromAssembly_InvalidProjection_ReturnsError()
+    {
+        var result = TypeAnalysisTools.GetTypesFromAssembly(_typeAnalysisService, _testAssemblyPath, projection: "partial");
+
+        Assert.Contains("InvalidProjection", result);
+    }
+
+    [Fact]
+    public void GetTypeMethods_DefaultProjection_IsSummary()
+    {
+        var typeName = typeof(TestSampleClass).FullName!;
+
+        var result = MemberAnalysisTools.GetTypeMethods(
+            _memberAnalysisService, _middleware, _runtimeOptions,
+            _testAssemblyPath, typeName, maxItems: 3);
+
+        Assert.DoesNotContain("\"error\"", result);
+        var jsonDoc = JsonDocument.Parse(result);
+        var data = jsonDoc.RootElement.GetProperty("data");
+
+        Assert.Equal("summary", data.GetProperty("projection").GetString());
+
+        var methods = data.GetProperty("methods");
+        Assert.True(methods.GetArrayLength() > 0, "Expected at least one method in the page");
+        var first = methods[0];
+
+        Assert.True(first.TryGetProperty("name", out _), "Summary method should have name");
+        Assert.True(first.TryGetProperty("signature", out _), "Summary method should have signature");
+
+        Assert.False(first.TryGetProperty("parameters", out _), "Summary method should NOT include parameters");
+        Assert.False(first.TryGetProperty("attributes", out _), "Summary method should NOT include attributes");
+        Assert.False(first.TryGetProperty("returnType", out _), "Summary method should NOT include returnType");
+    }
+
+    [Fact]
+    public void GetTypeMethods_FullProjection_IncludesParameters()
+    {
+        var typeName = typeof(TestSampleClass).FullName!;
+
+        var result = MemberAnalysisTools.GetTypeMethods(
+            _memberAnalysisService, _middleware, _runtimeOptions,
+            _testAssemblyPath, typeName, maxItems: 3, projection: "full");
+
+        Assert.DoesNotContain("\"error\"", result);
+        var jsonDoc = JsonDocument.Parse(result);
+        var data = jsonDoc.RootElement.GetProperty("data");
+
+        Assert.Equal("full", data.GetProperty("projection").GetString());
+
+        var methods = data.GetProperty("methods");
+        Assert.True(methods.GetArrayLength() > 0, "Expected at least one method in the page");
+        var first = methods[0];
+
+        Assert.True(first.TryGetProperty("parameters", out _), "Full method should include parameters");
+        Assert.True(first.TryGetProperty("returnType", out _), "Full method should include returnType");
+        Assert.True(first.TryGetProperty("attributes", out _), "Full method should include attributes");
+    }
+
+    [Fact]
+    public void GetTypeMethods_InvalidProjection_ReturnsError()
+    {
+        var typeName = typeof(TestSampleClass).FullName!;
+
+        var result = MemberAnalysisTools.GetTypeMethods(
+            _memberAnalysisService, _middleware, _runtimeOptions,
+            _testAssemblyPath, typeName, projection: "partial");
+
+        Assert.Contains("InvalidProjection", result);
+    }
+
+    [Fact]
     public void DefaultPageSize_UsesConfiguredValue()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Closes #21.

Adds an optional `projection` parameter to the two highest-impact listing tools. **Default is `summary`** — lean payloads so LLM consumers don't burn context on fields they didn't ask for. Pass `projection='full'` when the heavy fields are actually needed.

- `GetTypesFromAssembly`: summary returns `{ FullName, Namespace, Kind }`; full preserves the old `TypeInfo` shape (attributes, interfaces, generics, nested types).
- `GetTypeMethods`: summary returns `{ name, signature }` — the C# signature already encodes return type/params/modifiers; full returns the prior structured shape (`parameters[]`, `attributes`, `returnType`, modifier booleans).
- Tool `[Description]` attributes rewritten to tell the agent when to switch to `full`.
- `projection` included in the response envelope so callers can confirm what they got.
- For `GetTypeMethods`, `projection` participates in the cache key so summary and full responses are cached separately.
- Invalid projection values return `InvalidProjection`.

## Breaking change

This **is** a breaking change for direct callers that assumed the old payload shape — the default was flipped deliberately in favor of saner defaults on an LLM-consumed tool surface. Callers that want the old behavior should pass `projection: "full"`.

The original consumer report motivating this was a 147KB response from `get_types_from_assembly` blowing past token limits on a mid-size assembly — summary drops ~80% of typical response size.

## Test plan

- [x] `dotnet build src/Sherlock.MCP.sln` — clean
- [x] `dotnet test` — all 44 tests pass on net8.0 and net10.0 (net9.0 runtime not installed locally)
- [x] 6 new `[Fact]` tests in `PaginationTests.cs` covering: default-is-summary (both tools), full returns heavy fields (both tools), invalid projection returns `InvalidProjection` (both tools)
- [ ] Manual MCP smoke after merge: listing a real mid-size assembly with no projection arg should be dramatically smaller than before; `projection: "full"` should match the prior shape

## Follow-up

- Extend projection to `GetTypeProperties`, `GetTypeFields`, `GetTypeEvents`, `GetTypeConstructors`, `GetAllTypeMembers` (separate issue).
- Issue #22 (reverse-lookup tools) should adopt this contract from day one.