### PR TITLE
feat(tools): add reverse-lookup tools (implementations, returns, references)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Three new reverse-lookup MCP tools for answering "what implements / returns / references this type?" across one or more assemblies: `FindImplementationsOf`, `FindMethodsReturning`, `FindReferencesTo`. All three follow the existing pagination / projection / caching conventions (summary vs full). `FindReferencesTo` enforces a hard scan cap (defaults to max(maxItems*4, 500)) and reports `truncated: true` when hit. A new `TypeNameMatcher` normalizes simple, full, open-generic (`Foo<>`, `Foo<T>`, `Foo\`1`), nested (`Outer+Inner` or `Outer.Inner`), array/byref/pointer, nullable (`int?`), and built-in alias (`int`, `string`) forms. (#22)
+
 ## [2.7.2] - 2026-04-18
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,16 +32,17 @@ This is a comprehensive .NET MCP (Model Context Protocol) server called "Sherloc
 This MCP server provides LLMs with comprehensive .NET reflection capabilities through several key architectural principles:
 
 ### Assembly-First Discovery
-Since the MCP server runs as a separate process, it cannot access the client's loaded assemblies. Instead, it provides 28+ specialized tools for clients to:
+Since the MCP server runs as a separate process, it cannot access the client's loaded assemblies. Instead, it provides 31+ specialized tools for clients to:
 1. **Discover assemblies** using multiple strategies (project analysis, class name search, file system scanning)
 2. **Load and analyze** specific assemblies by path with efficient caching
 3. **Deep introspection** of types, members, attributes, and XML documentation
 4. **Performance optimization** through pagination, streaming, and response size validation
 
-### Tool Categories (28+ Available)
+### Tool Categories (31+ Available)
 - **Assembly Discovery & Analysis** (3 tools): `AnalyzeAssembly`, `FindAssemblyByClassName`, `FindAssemblyByFileName`
 - **Type Introspection** (7 tools): `GetTypesFromAssembly`, `GetTypeInfo`, `GetTypeHierarchy`, etc.
 - **Member Analysis** (8 tools): `GetTypeMethods`, `GetTypeProperties`, `GetAllTypeMembers`, etc.
+- **Reverse Lookup** (3 tools): `FindImplementationsOf`, `FindMethodsReturning`, `FindReferencesTo`
 - **Attributes & Metadata** (2 tools): `GetMemberAttributes`, `GetParameterAttributes`
 - **XML Documentation** (2 tools): `GetXmlDocsForType`, `GetXmlDocsForMember`
 - **Project Analysis** (5 tools): `AnalyzeSolution`, `AnalyzeProject`, `ResolvePackageReferences`, etc.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This tool is essential for developers who want to harness LLM capabilities for:
 
 ## Key Features
 
-*   **Comprehensive MCP Server**: Provides 28+ specialized tools for .NET assembly analysis
+*   **Comprehensive MCP Server**: Provides 31+ specialized tools for .NET assembly analysis
 *   **Advanced Assembly Introspection**: Deep reflection-based analysis of types, members, and metadata
 *   **Rich Member Analysis**: Detailed inspection of methods, properties, fields, events, and constructors
 *   **Smart Filtering & Pagination**: Advanced filtering by name/attributes with efficient pagination for large datasets
@@ -159,6 +159,11 @@ Use GetTypeMethods on /abs/path/MyLib.dll, type MyNamespace.MyType, sortBy name,
 - **`GetTypeEvents`**: Event declarations with handler types
 - **`GetTypeConstructors`**: Constructor signatures and parameters
 - **`AnalyzeMethod`**: Deep method analysis with overloads and attributes
+
+### Reverse Lookup
+- **`FindImplementationsOf`**: Types implementing an interface or deriving from a base class
+- **`FindMethodsReturning`**: Methods whose return type matches a given type (open-generic match supported)
+- **`FindReferencesTo`**: Broader sweep across parameters, fields, properties, events, and generic arguments
 
 ### Attributes & Metadata
 - **`GetMemberAttributes`**: Attributes for specific members

--- a/src/runtime/Contracts/ReverseLookup/ImplementationHit.cs
+++ b/src/runtime/Contracts/ReverseLookup/ImplementationHit.cs
@@ -1,0 +1,8 @@
+namespace Sherlock.MCP.Runtime.Contracts.ReverseLookup;
+
+public record ImplementationHit(
+    string AssemblyPath,
+    string TypeFullName,
+    string Kind,
+    string[] MatchedInterfaces,
+    string[] BaseTypeChain);

--- a/src/runtime/Contracts/ReverseLookup/MethodReturnHit.cs
+++ b/src/runtime/Contracts/ReverseLookup/MethodReturnHit.cs
@@ -1,0 +1,9 @@
+namespace Sherlock.MCP.Runtime.Contracts.ReverseLookup;
+
+public record MethodReturnHit(
+    string AssemblyPath,
+    string DeclaringTypeFullName,
+    string MethodName,
+    string Signature,
+    string ReturnTypeFriendlyName,
+    bool IsStatic);

--- a/src/runtime/Contracts/ReverseLookup/ReferenceHit.cs
+++ b/src/runtime/Contracts/ReverseLookup/ReferenceHit.cs
@@ -1,0 +1,10 @@
+namespace Sherlock.MCP.Runtime.Contracts.ReverseLookup;
+
+public record ReferenceHit(
+    string AssemblyPath,
+    string DeclaringTypeFullName,
+    string MemberKind,
+    string MemberName,
+    string ReferenceKind,
+    string Signature,
+    string DedupeKey);

--- a/src/runtime/Contracts/ReverseLookup/ReverseLookupOptions.cs
+++ b/src/runtime/Contracts/ReverseLookup/ReverseLookupOptions.cs
@@ -1,0 +1,6 @@
+namespace Sherlock.MCP.Runtime.Contracts.ReverseLookup;
+
+public record ReverseLookupOptions(
+    bool CaseSensitive = false,
+    bool IncludeNonPublic = false,
+    int HardCap = 500);

--- a/src/runtime/IReverseLookupService.cs
+++ b/src/runtime/IReverseLookupService.cs
@@ -1,0 +1,14 @@
+using Sherlock.MCP.Runtime.Contracts.ReverseLookup;
+
+namespace Sherlock.MCP.Runtime;
+
+public interface IReverseLookupService
+{
+    ImplementationHit[] FindImplementations(string[] assemblyPaths, string typeName, ReverseLookupOptions options);
+
+    MethodReturnHit[] FindMethodsReturning(string[] assemblyPaths, string typeName, ReverseLookupOptions options);
+
+    ReferencesResult FindReferences(string[] assemblyPaths, string typeName, ReverseLookupOptions options);
+}
+
+public record ReferencesResult(ReferenceHit[] Hits, bool Truncated);

--- a/src/runtime/ReverseLookupService.cs
+++ b/src/runtime/ReverseLookupService.cs
@@ -13,31 +13,32 @@ public class ReverseLookupService : IReverseLookupService
         foreach (var path in assemblyPaths)
         {
             if (!File.Exists(path)) continue;
-
-            using var ctx = InspectionContextFactory.Create(path);
-            foreach (var candidate in GetScannableTypes(ctx, options))
+            if (!TryScanAssembly(path, ctx =>
             {
-                var matchedInterfaces = GetInterfacesSafe(candidate)
-                    .Where(i => TypeNameMatcher.Matches(i, typeName, options.CaseSensitive))
-                    .Select(i => i.FullName ?? i.Name)
-                    .ToArray();
+                foreach (var candidate in GetScannableTypes(ctx, options))
+                {
+                    var matchedInterfaces = GetInterfacesSafe(candidate)
+                        .Where(i => TypeNameMatcher.Matches(i, typeName, options.CaseSensitive))
+                        .Select(i => i.FullName ?? i.Name)
+                        .ToArray();
 
-                var baseTypeChain = GetBaseTypeChain(candidate);
-                var matchedBases = baseTypeChain
-                    .Where(b => TypeNameMatcher.Matches(b, typeName, options.CaseSensitive))
-                    .Select(b => b.FullName ?? b.Name)
-                    .ToArray();
+                    var baseTypeChain = GetBaseTypeChain(candidate);
+                    var matchedBases = baseTypeChain
+                        .Where(b => TypeNameMatcher.Matches(b, typeName, options.CaseSensitive))
+                        .Select(b => b.FullName ?? b.Name)
+                        .ToArray();
 
-                if (matchedInterfaces.Length == 0 && matchedBases.Length == 0) continue;
+                    if (matchedInterfaces.Length == 0 && matchedBases.Length == 0) continue;
 
-                var kind = matchedInterfaces.Length > 0 ? "interface" : "baseType";
-                hits.Add(new ImplementationHit(
-                    AssemblyPath: path,
-                    TypeFullName: candidate.FullName ?? candidate.Name,
-                    Kind: kind,
-                    MatchedInterfaces: matchedInterfaces,
-                    BaseTypeChain: baseTypeChain.Select(b => b.FullName ?? b.Name).ToArray()));
-            }
+                    var kind = matchedInterfaces.Length > 0 ? "interface" : "baseType";
+                    hits.Add(new ImplementationHit(
+                        AssemblyPath: path,
+                        TypeFullName: candidate.FullName ?? candidate.Name,
+                        Kind: kind,
+                        MatchedInterfaces: matchedInterfaces,
+                        BaseTypeChain: baseTypeChain.Select(b => b.FullName ?? b.Name).ToArray()));
+                }
+            })) continue;
         }
 
         return hits
@@ -54,27 +55,28 @@ public class ReverseLookupService : IReverseLookupService
         foreach (var path in assemblyPaths)
         {
             if (!File.Exists(path)) continue;
-
-            using var ctx = InspectionContextFactory.Create(path);
-            foreach (var candidate in GetScannableTypes(ctx, options))
+            if (!TryScanAssembly(path, ctx =>
             {
-                foreach (var method in GetMethodsSafe(candidate, flags))
+                foreach (var candidate in GetScannableTypes(ctx, options))
                 {
-                    Type? returnType;
-                    try { returnType = method.ReturnType; }
-                    catch { continue; }
+                    foreach (var method in GetMethodsSafe(candidate, flags))
+                    {
+                        Type? returnType;
+                        try { returnType = method.ReturnType; }
+                        catch { continue; }
 
-                    if (!TypeNameMatcher.Matches(returnType, typeName, options.CaseSensitive)) continue;
+                        if (!TypeNameMatcher.Matches(returnType, typeName, options.CaseSensitive)) continue;
 
-                    hits.Add(new MethodReturnHit(
-                        AssemblyPath: path,
-                        DeclaringTypeFullName: candidate.FullName ?? candidate.Name,
-                        MethodName: method.Name,
-                        Signature: FormatMethodSignature(method),
-                        ReturnTypeFriendlyName: FriendlyTypeName(returnType),
-                        IsStatic: method.IsStatic));
+                        hits.Add(new MethodReturnHit(
+                            AssemblyPath: path,
+                            DeclaringTypeFullName: candidate.FullName ?? candidate.Name,
+                            MethodName: method.Name,
+                            Signature: FormatMethodSignature(method),
+                            ReturnTypeFriendlyName: FriendlyTypeName(returnType),
+                            IsStatic: method.IsStatic));
+                    }
                 }
-            }
+            })) continue;
         }
 
         return hits
@@ -97,7 +99,16 @@ public class ReverseLookupService : IReverseLookupService
             if (truncated) break;
             if (!File.Exists(path)) continue;
 
-            using var ctx = InspectionContextFactory.Create(path);
+            IAssemblyInspectionContext? ctx;
+            try { ctx = InspectionContextFactory.Create(path); }
+            catch (BadImageFormatException) { continue; }
+            catch (FileLoadException) { continue; }
+            catch (ReflectionTypeLoadException) { continue; }
+            catch (IOException) { continue; }
+
+            using (ctx)
+            try
+            {
             foreach (var candidate in GetScannableTypes(ctx, options))
             {
                 if (hits.Count >= cap) { truncated = true; break; }
@@ -208,6 +219,11 @@ public class ReverseLookupService : IReverseLookupService
                         disambiguator: eventMatch.FullName ?? eventMatch.Name));
                 }
             }
+            }
+            catch (BadImageFormatException) { }
+            catch (FileLoadException) { }
+            catch (ReflectionTypeLoadException) { }
+            catch (IOException) { }
         }
 
         var sorted = hits
@@ -224,9 +240,32 @@ public class ReverseLookupService : IReverseLookupService
 
     private static ReferenceHit MakeRefHit(
         string assemblyPath, string declaringType, string memberKind, string memberName,
-        string referenceKind, string signature, string disambiguator) =>
-        new(assemblyPath, declaringType, memberKind, memberName, referenceKind, signature,
-            DedupeKey: $"{declaringType}|{memberKind}|{memberName}|{referenceKind}|{disambiguator}");
+        string referenceKind, string signature, string disambiguator)
+    {
+        var isMethodLike =
+            string.Equals(memberKind, "method", StringComparison.Ordinal) ||
+            string.Equals(memberKind, "constructor", StringComparison.Ordinal);
+
+        var dedupeKey = isMethodLike
+            ? $"{declaringType}|{memberKind}|{memberName}|{referenceKind}|{signature}|{disambiguator}"
+            : $"{declaringType}|{memberKind}|{memberName}|{referenceKind}|{disambiguator}";
+
+        return new(assemblyPath, declaringType, memberKind, memberName, referenceKind, signature, dedupeKey);
+    }
+
+    private static bool TryScanAssembly(string path, Action<IAssemblyInspectionContext> scan)
+    {
+        try
+        {
+            using var ctx = InspectionContextFactory.Create(path);
+            scan(ctx);
+            return true;
+        }
+        catch (BadImageFormatException) { return false; }
+        catch (FileLoadException) { return false; }
+        catch (ReflectionTypeLoadException) { return false; }
+        catch (IOException) { return false; }
+    }
 
     private static Type? FindMatchingType(Type? container, string userName, bool caseSensitive)
     {

--- a/src/runtime/ReverseLookupService.cs
+++ b/src/runtime/ReverseLookupService.cs
@@ -1,0 +1,387 @@
+using System.Reflection;
+using Sherlock.MCP.Runtime.Contracts.ReverseLookup;
+using Sherlock.MCP.Runtime.Inspection;
+
+namespace Sherlock.MCP.Runtime;
+
+public class ReverseLookupService : IReverseLookupService
+{
+    public ImplementationHit[] FindImplementations(string[] assemblyPaths, string typeName, ReverseLookupOptions options)
+    {
+        var hits = new List<ImplementationHit>();
+
+        foreach (var path in assemblyPaths)
+        {
+            if (!File.Exists(path)) continue;
+
+            using var ctx = InspectionContextFactory.Create(path);
+            foreach (var candidate in GetScannableTypes(ctx, options))
+            {
+                var matchedInterfaces = GetInterfacesSafe(candidate)
+                    .Where(i => TypeNameMatcher.Matches(i, typeName, options.CaseSensitive))
+                    .Select(i => i.FullName ?? i.Name)
+                    .ToArray();
+
+                var baseTypeChain = GetBaseTypeChain(candidate);
+                var matchedBases = baseTypeChain
+                    .Where(b => TypeNameMatcher.Matches(b, typeName, options.CaseSensitive))
+                    .Select(b => b.FullName ?? b.Name)
+                    .ToArray();
+
+                if (matchedInterfaces.Length == 0 && matchedBases.Length == 0) continue;
+
+                var kind = matchedInterfaces.Length > 0 ? "interface" : "baseType";
+                hits.Add(new ImplementationHit(
+                    AssemblyPath: path,
+                    TypeFullName: candidate.FullName ?? candidate.Name,
+                    Kind: kind,
+                    MatchedInterfaces: matchedInterfaces,
+                    BaseTypeChain: baseTypeChain.Select(b => b.FullName ?? b.Name).ToArray()));
+            }
+        }
+
+        return hits
+            .OrderBy(h => h.AssemblyPath, StringComparer.Ordinal)
+            .ThenBy(h => h.TypeFullName, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    public MethodReturnHit[] FindMethodsReturning(string[] assemblyPaths, string typeName, ReverseLookupOptions options)
+    {
+        var hits = new List<MethodReturnHit>();
+        var flags = BuildMemberFlags(options);
+
+        foreach (var path in assemblyPaths)
+        {
+            if (!File.Exists(path)) continue;
+
+            using var ctx = InspectionContextFactory.Create(path);
+            foreach (var candidate in GetScannableTypes(ctx, options))
+            {
+                foreach (var method in GetMethodsSafe(candidate, flags))
+                {
+                    Type? returnType;
+                    try { returnType = method.ReturnType; }
+                    catch { continue; }
+
+                    if (!TypeNameMatcher.Matches(returnType, typeName, options.CaseSensitive)) continue;
+
+                    hits.Add(new MethodReturnHit(
+                        AssemblyPath: path,
+                        DeclaringTypeFullName: candidate.FullName ?? candidate.Name,
+                        MethodName: method.Name,
+                        Signature: FormatMethodSignature(method),
+                        ReturnTypeFriendlyName: FriendlyTypeName(returnType),
+                        IsStatic: method.IsStatic));
+                }
+            }
+        }
+
+        return hits
+            .OrderBy(h => h.AssemblyPath, StringComparer.Ordinal)
+            .ThenBy(h => h.DeclaringTypeFullName, StringComparer.Ordinal)
+            .ThenBy(h => h.MethodName, StringComparer.Ordinal)
+            .ThenBy(h => h.Signature, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    public ReferencesResult FindReferences(string[] assemblyPaths, string typeName, ReverseLookupOptions options)
+    {
+        var hits = new List<ReferenceHit>();
+        var flags = BuildMemberFlags(options);
+        var cap = Math.Max(1, options.HardCap);
+        var truncated = false;
+
+        foreach (var path in assemblyPaths)
+        {
+            if (truncated) break;
+            if (!File.Exists(path)) continue;
+
+            using var ctx = InspectionContextFactory.Create(path);
+            foreach (var candidate in GetScannableTypes(ctx, options))
+            {
+                if (hits.Count >= cap) { truncated = true; break; }
+
+                var declaringName = candidate.FullName ?? candidate.Name;
+
+                Type? baseType = null;
+                try { baseType = candidate.BaseType; } catch { }
+                if (baseType != null && TypeNameMatcher.Matches(baseType, typeName, options.CaseSensitive))
+                {
+                    hits.Add(MakeRefHit(path, declaringName, "type", declaringName, "baseType",
+                        $"{declaringName} : {FriendlyTypeName(baseType)}",
+                        disambiguator: baseType.FullName ?? baseType.Name));
+                }
+
+                foreach (var iface in GetInterfacesSafe(candidate))
+                {
+                    if (hits.Count >= cap) { truncated = true; break; }
+                    if (!TypeNameMatcher.Matches(iface, typeName, options.CaseSensitive)) continue;
+                    hits.Add(MakeRefHit(path, declaringName, "type", declaringName, "interface",
+                        $"{declaringName} : {FriendlyTypeName(iface)}",
+                        disambiguator: iface.FullName ?? iface.Name));
+                }
+
+                if (truncated) break;
+
+                if (candidate.IsGenericType)
+                {
+                    Type[] args;
+                    try { args = candidate.GetGenericArguments(); } catch { args = Array.Empty<Type>(); }
+                    foreach (var arg in args)
+                    {
+                        if (hits.Count >= cap) { truncated = true; break; }
+                        if (!TypeNameMatcher.Matches(arg, typeName, options.CaseSensitive)) continue;
+                        hits.Add(MakeRefHit(path, declaringName, "type", declaringName, "genericArg",
+                            $"{declaringName}<{FriendlyTypeName(arg)}>",
+                            disambiguator: arg.FullName ?? arg.Name));
+                    }
+                    if (truncated) break;
+                }
+
+                foreach (var method in GetMethodsSafe(candidate, flags))
+                {
+                    if (hits.Count >= cap) { truncated = true; break; }
+                    var sig = FormatMethodSignature(method);
+
+                    Type? returnType = null;
+                    try { returnType = method.ReturnType; } catch { }
+                    var returnMatch = FindMatchingType(returnType, typeName, options.CaseSensitive);
+                    if (returnMatch != null)
+                    {
+                        hits.Add(MakeRefHit(path, declaringName, "method", method.Name, "return", sig,
+                            disambiguator: returnMatch.FullName ?? returnMatch.Name));
+                    }
+
+                    ParameterInfo[] parameters;
+                    try { parameters = method.GetParameters(); } catch { parameters = Array.Empty<ParameterInfo>(); }
+                    foreach (var p in parameters)
+                    {
+                        if (hits.Count >= cap) { truncated = true; break; }
+                        Type? pt;
+                        try { pt = p.ParameterType; } catch { continue; }
+                        if (FindMatchingType(pt, typeName, options.CaseSensitive) == null) continue;
+                        hits.Add(MakeRefHit(path, declaringName, "method", method.Name, "parameter", sig,
+                            disambiguator: p.Name ?? p.Position.ToString()));
+                    }
+                }
+
+                if (truncated) break;
+
+                foreach (var prop in GetPropertiesSafe(candidate, flags))
+                {
+                    if (hits.Count >= cap) { truncated = true; break; }
+                    Type? pt;
+                    try { pt = prop.PropertyType; } catch { continue; }
+                    var propMatch = FindMatchingType(pt, typeName, options.CaseSensitive);
+                    if (propMatch == null) continue;
+                    hits.Add(MakeRefHit(path, declaringName, "property", prop.Name, "property",
+                        $"{FriendlyTypeName(pt)} {prop.Name}",
+                        disambiguator: propMatch.FullName ?? propMatch.Name));
+                }
+
+                if (truncated) break;
+
+                foreach (var field in GetFieldsSafe(candidate, flags))
+                {
+                    if (hits.Count >= cap) { truncated = true; break; }
+                    Type? ft;
+                    try { ft = field.FieldType; } catch { continue; }
+                    var fieldMatch = FindMatchingType(ft, typeName, options.CaseSensitive);
+                    if (fieldMatch == null) continue;
+                    hits.Add(MakeRefHit(path, declaringName, "field", field.Name, "field",
+                        $"{FriendlyTypeName(ft)} {field.Name}",
+                        disambiguator: fieldMatch.FullName ?? fieldMatch.Name));
+                }
+
+                if (truncated) break;
+
+                foreach (var evt in GetEventsSafe(candidate, flags))
+                {
+                    if (hits.Count >= cap) { truncated = true; break; }
+                    Type? et;
+                    try { et = evt.EventHandlerType; } catch { continue; }
+                    var eventMatch = FindMatchingType(et, typeName, options.CaseSensitive);
+                    if (eventMatch == null) continue;
+                    hits.Add(MakeRefHit(path, declaringName, "event", evt.Name, "event",
+                        $"event {FriendlyTypeName(et!)} {evt.Name}",
+                        disambiguator: eventMatch.FullName ?? eventMatch.Name));
+                }
+            }
+        }
+
+        var sorted = hits
+            .OrderBy(h => h.AssemblyPath, StringComparer.Ordinal)
+            .ThenBy(h => h.DeclaringTypeFullName, StringComparer.Ordinal)
+            .ThenBy(h => h.MemberKind, StringComparer.Ordinal)
+            .ThenBy(h => h.MemberName, StringComparer.Ordinal)
+            .ThenBy(h => h.ReferenceKind, StringComparer.Ordinal)
+            .ThenBy(h => h.DedupeKey, StringComparer.Ordinal)
+            .ToArray();
+
+        return new ReferencesResult(sorted, truncated);
+    }
+
+    private static ReferenceHit MakeRefHit(
+        string assemblyPath, string declaringType, string memberKind, string memberName,
+        string referenceKind, string signature, string disambiguator) =>
+        new(assemblyPath, declaringType, memberKind, memberName, referenceKind, signature,
+            DedupeKey: $"{declaringType}|{memberKind}|{memberName}|{referenceKind}|{disambiguator}");
+
+    private static Type? FindMatchingType(Type? container, string userName, bool caseSensitive)
+    {
+        if (container == null) return null;
+        if (TypeNameMatcher.Matches(container, userName, caseSensitive)) return container;
+
+        Type? inner = null;
+        try { inner = container.IsGenericType ? null : container.GetElementType(); }
+        catch { inner = null; }
+        if (inner != null)
+        {
+            var match = FindMatchingType(inner, userName, caseSensitive);
+            if (match != null) return match;
+        }
+
+        if (container.IsGenericType)
+        {
+            Type[] args;
+            try { args = container.GetGenericArguments(); } catch { args = Array.Empty<Type>(); }
+            foreach (var arg in args)
+            {
+                var match = FindMatchingType(arg, userName, caseSensitive);
+                if (match != null) return match;
+            }
+        }
+        return null;
+    }
+
+    private static BindingFlags BuildMemberFlags(ReverseLookupOptions options)
+    {
+        var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+        if (options.IncludeNonPublic) flags |= BindingFlags.NonPublic;
+        return flags;
+    }
+
+    private static IEnumerable<Type> GetScannableTypes(IAssemblyInspectionContext ctx, ReverseLookupOptions options)
+    {
+        IEnumerable<Type> types;
+        try { types = ctx.GetTypes(); }
+        catch { yield break; }
+
+        foreach (var t in types)
+        {
+            if (t == null) continue;
+            if (t.IsGenericParameter) continue;
+            if (!options.IncludeNonPublic && !t.IsPublic && !t.IsNestedPublic) continue;
+            yield return t;
+        }
+    }
+
+    private static Type[] GetInterfacesSafe(Type t)
+    {
+        try { return t.GetInterfaces(); }
+        catch { return Array.Empty<Type>(); }
+    }
+
+    private static List<Type> GetBaseTypeChain(Type t)
+    {
+        var chain = new List<Type>();
+        try
+        {
+            var current = t.BaseType;
+            while (current != null)
+            {
+                chain.Add(current);
+                current = current.BaseType;
+            }
+        }
+        catch { }
+        return chain;
+    }
+
+    private static MethodInfo[] GetMethodsSafe(Type t, BindingFlags flags)
+    {
+        try { return t.GetMethods(flags).Where(m => !m.IsSpecialName).ToArray(); }
+        catch { return Array.Empty<MethodInfo>(); }
+    }
+
+    private static PropertyInfo[] GetPropertiesSafe(Type t, BindingFlags flags)
+    {
+        try { return t.GetProperties(flags); }
+        catch { return Array.Empty<PropertyInfo>(); }
+    }
+
+    private static FieldInfo[] GetFieldsSafe(Type t, BindingFlags flags)
+    {
+        try { return t.GetFields(flags); }
+        catch { return Array.Empty<FieldInfo>(); }
+    }
+
+    private static EventInfo[] GetEventsSafe(Type t, BindingFlags flags)
+    {
+        try { return t.GetEvents(flags); }
+        catch { return Array.Empty<EventInfo>(); }
+    }
+
+    private static string FormatMethodSignature(MethodInfo m)
+    {
+        string ret;
+        try { ret = FriendlyTypeName(m.ReturnType); }
+        catch { ret = "?"; }
+
+        ParameterInfo[] parameters;
+        try { parameters = m.GetParameters(); }
+        catch { parameters = Array.Empty<ParameterInfo>(); }
+
+        var ps = string.Join(", ", parameters.Select(p =>
+        {
+            string pt;
+            try { pt = FriendlyTypeName(p.ParameterType); }
+            catch { pt = "?"; }
+            return $"{pt} {p.Name}";
+        }));
+
+        return $"{ret} {m.Name}({ps})";
+    }
+
+    private static readonly Dictionary<string, string> FriendlyBuiltIns = new(StringComparer.Ordinal)
+    {
+        ["System.Boolean"] = "bool",
+        ["System.Byte"] = "byte",
+        ["System.SByte"] = "sbyte",
+        ["System.Char"] = "char",
+        ["System.Decimal"] = "decimal",
+        ["System.Double"] = "double",
+        ["System.Single"] = "float",
+        ["System.Int32"] = "int",
+        ["System.UInt32"] = "uint",
+        ["System.Int64"] = "long",
+        ["System.UInt64"] = "ulong",
+        ["System.Object"] = "object",
+        ["System.Int16"] = "short",
+        ["System.UInt16"] = "ushort",
+        ["System.String"] = "string",
+        ["System.Void"] = "void"
+    };
+
+    private static string FriendlyTypeName(Type t)
+    {
+        if (t.IsByRef) return FriendlyTypeName(t.GetElementType()!) + "&";
+        if (t.IsPointer) return FriendlyTypeName(t.GetElementType()!) + "*";
+        if (t.IsArray)
+        {
+            var rank = t.GetArrayRank();
+            var brackets = rank == 1 ? "[]" : "[" + new string(',', rank - 1) + "]";
+            return FriendlyTypeName(t.GetElementType()!) + brackets;
+        }
+        if (t.IsGenericType)
+        {
+            var def = t.GetGenericTypeDefinition().Name;
+            var backtick = def.IndexOf('`');
+            if (backtick > 0) def = def.Substring(0, backtick);
+            var args = string.Join(", ", t.GetGenericArguments().Select(FriendlyTypeName));
+            return $"{def}<{args}>";
+        }
+        return t.FullName is string fn && FriendlyBuiltIns.TryGetValue(fn, out var alias) ? alias : t.Name;
+    }
+}

--- a/src/runtime/RuntimeOptions.cs
+++ b/src/runtime/RuntimeOptions.cs
@@ -20,7 +20,10 @@ public class RuntimeOptions
             ["GetAllTypeMembers"] = 20,    // Combined view, keep small
             ["AnalyzeAssembly"] = 50,      // Type summaries
             ["AnalyzeType"] = 25,          // Combined members
-            ["GetTypesFromAssembly"] = 50  // Type summaries
+            ["GetTypesFromAssembly"] = 50, // Type summaries
+            ["FindImplementationsOf"] = 50,
+            ["FindMethodsReturning"] = 50,
+            ["FindReferencesTo"] = 25      // Broader sweep, keep smaller
         };
     }
 

--- a/src/runtime/TypeNameMatcher.cs
+++ b/src/runtime/TypeNameMatcher.cs
@@ -1,0 +1,148 @@
+namespace Sherlock.MCP.Runtime;
+
+public static class TypeNameMatcher
+{
+    private static readonly Dictionary<string, string> BuiltInToClrName = new(StringComparer.Ordinal)
+    {
+        ["bool"] = "Boolean",
+        ["byte"] = "Byte",
+        ["sbyte"] = "SByte",
+        ["char"] = "Char",
+        ["decimal"] = "Decimal",
+        ["double"] = "Double",
+        ["float"] = "Single",
+        ["int"] = "Int32",
+        ["uint"] = "UInt32",
+        ["long"] = "Int64",
+        ["ulong"] = "UInt64",
+        ["object"] = "Object",
+        ["short"] = "Int16",
+        ["ushort"] = "UInt16",
+        ["string"] = "String",
+        ["void"] = "Void",
+        ["nint"] = "IntPtr",
+        ["nuint"] = "UIntPtr"
+    };
+
+    public static bool Matches(Type? candidate, string? userSuppliedName, bool caseSensitive = false)
+    {
+        if (candidate == null) return false;
+        if (string.IsNullOrWhiteSpace(userSuppliedName)) return false;
+        if (candidate.IsGenericParameter) return false;
+
+        if (candidate.IsArray || candidate.IsByRef || candidate.IsPointer)
+        {
+            var elem = candidate.GetElementType();
+            return elem != null && Matches(elem, userSuppliedName, caseSensitive);
+        }
+
+        var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        var candidateVariants = GetCandidateNameVariants(candidate).ToArray();
+
+        foreach (var userVariant in ExpandUserNameVariants(userSuppliedName!, caseSensitive))
+        {
+            if (string.IsNullOrEmpty(userVariant)) continue;
+            foreach (var candidateName in candidateVariants)
+            {
+                if (string.Equals(candidateName, userVariant, comparison)) return true;
+            }
+        }
+        return false;
+    }
+
+    private static IEnumerable<string> ExpandUserNameVariants(string userSuppliedName, bool caseSensitive)
+    {
+        var s = userSuppliedName.Trim();
+
+        var commaIdx = s.IndexOf(',');
+        if (commaIdx >= 0) s = s.Substring(0, commaIdx).Trim();
+
+        s = s.Replace('+', '.');
+
+        yield return s;
+        var stripped = StripArityAndArgs(s);
+        yield return stripped;
+
+        if (TryGetBuiltInClrName(stripped, caseSensitive, out var clr))
+        {
+            yield return clr;
+            yield return "System." + clr;
+        }
+
+        if (s.EndsWith("?") && s.Length > 1)
+        {
+            var inner = s.Substring(0, s.Length - 1).Trim();
+            yield return $"Nullable<{inner}>";
+            yield return $"System.Nullable<{inner}>";
+            yield return "Nullable";
+            yield return "System.Nullable";
+            if (TryGetBuiltInClrName(inner, caseSensitive, out var innerClr))
+            {
+                yield return innerClr;
+                yield return "System." + innerClr;
+            }
+            else
+            {
+                yield return inner;
+            }
+        }
+    }
+
+    private static bool TryGetBuiltInClrName(string alias, bool caseSensitive, out string clrName)
+    {
+        if (caseSensitive)
+            return BuiltInToClrName.TryGetValue(alias, out clrName!);
+
+        foreach (var kvp in BuiltInToClrName)
+        {
+            if (string.Equals(kvp.Key, alias, StringComparison.OrdinalIgnoreCase))
+            {
+                clrName = kvp.Value;
+                return true;
+            }
+        }
+        clrName = string.Empty;
+        return false;
+    }
+
+    private static IEnumerable<string> GetCandidateNameVariants(Type candidate)
+    {
+        var full = (candidate.FullName ?? candidate.Name).Replace('+', '.');
+        var simple = candidate.Name;
+
+        yield return full;
+        yield return simple;
+
+        var fullStripped = StripArityAndArgs(full);
+        var simpleStripped = StripArityAndArgs(simple);
+        yield return fullStripped;
+        yield return simpleStripped;
+
+        foreach (var suffix in DottedSuffixes(full))
+            yield return suffix;
+        foreach (var suffix in DottedSuffixes(fullStripped))
+            yield return suffix;
+    }
+
+    private static IEnumerable<string> DottedSuffixes(string dotted)
+    {
+        var idx = 0;
+        while (true)
+        {
+            var nextDot = dotted.IndexOf('.', idx);
+            if (nextDot < 0) yield break;
+            var suffix = dotted.Substring(nextDot + 1);
+            if (suffix.Length > 0) yield return suffix;
+            idx = nextDot + 1;
+        }
+    }
+
+    private static string StripArityAndArgs(string name)
+    {
+        var bracketIdx = name.IndexOf('<');
+        if (bracketIdx >= 0) name = name.Substring(0, bracketIdx);
+        var backtickIdx = name.IndexOf('`');
+        if (backtickIdx >= 0) name = name.Substring(0, backtickIdx);
+        return name;
+    }
+}

--- a/src/server/Program.cs
+++ b/src/server/Program.cs
@@ -32,6 +32,7 @@ builder.Services
     .AddSingleton<ITypeAnalysisService, TypeAnalysisService>()
     .AddSingleton<IXmlDocService, XmlDocService>()
     .AddSingleton<IProjectAnalysisService, ProjectAnalysisService>()
+    .AddSingleton<IReverseLookupService, ReverseLookupService>()
     .AddSingleton<ToolMiddleware>()
     .AddMcpServer()
     .WithStdioServerTransport()

--- a/src/server/Tools/ReverseLookupTools.cs
+++ b/src/server/Tools/ReverseLookupTools.cs
@@ -328,7 +328,15 @@ public static class ReverseLookupTools
         if (!File.Exists(assemblyPath))
             return new ScopeResult { Error = JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}") };
 
-        var paths = new List<string> { assemblyPath };
+        var pathComparer = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        var seen = new HashSet<string>(pathComparer);
+        var paths = new List<string>();
+
+        var normalizedPrimary = Path.GetFullPath(assemblyPath);
+        if (seen.Add(normalizedPrimary)) paths.Add(normalizedPrimary);
+
         if (additionalAssemblies != null)
         {
             foreach (var extra in additionalAssemblies)
@@ -336,7 +344,8 @@ public static class ReverseLookupTools
                 if (string.IsNullOrWhiteSpace(extra)) continue;
                 if (!File.Exists(extra))
                     return new ScopeResult { Error = JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {extra}") };
-                paths.Add(extra);
+                var normalizedExtra = Path.GetFullPath(extra);
+                if (seen.Add(normalizedExtra)) paths.Add(normalizedExtra);
             }
         }
         return new ScopeResult { Paths = paths.ToArray() };

--- a/src/server/Tools/ReverseLookupTools.cs
+++ b/src/server/Tools/ReverseLookupTools.cs
@@ -1,0 +1,344 @@
+using ModelContextProtocol.Server;
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Contracts.ReverseLookup;
+using Sherlock.MCP.Server.Middleware;
+using Sherlock.MCP.Server.Shared;
+using System.ComponentModel;
+using System.Text.Json;
+
+namespace Sherlock.MCP.Server.Tools;
+
+[McpServerToolType]
+public static class ReverseLookupTools
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+
+    [McpServerTool]
+    [Description("Finds types that implement an interface or derive from a base type, across one or more assemblies. Returns a lean summary ({ typeFullName, kind }) by default. Pass projection='full' for matchedInterfaces[] and baseTypeChain[]. Matches by simple name, full name, or open-generic form (e.g., 'IEnumerable', 'IEnumerable<T>', 'IEnumerable<>', 'IEnumerable`1').")]
+    public static string FindImplementationsOf(
+        IReverseLookupService reverseLookup,
+        ToolMiddleware middleware,
+        RuntimeOptions runtimeOptions,
+        [Description("Path to the primary .NET assembly file (.dll or .exe)")] string assemblyPath,
+        [Description("Type name to find implementers of. Interface name (e.g., 'IDisposable') or base class name (e.g., 'Stream'). Simple name, full name, or generic variants accepted.")] string typeName,
+        [Description("Optional additional assembly paths to include in the search scope")] string[]? additionalAssemblies = null,
+        [Description("Case sensitive type-name matching (default: false)")] bool caseSensitive = false,
+        [Description("Include non-public types (default: false)")] bool includeNonPublic = false,
+        [Description("Maximum items to return (default: 50)")] int? maxItems = null,
+        [Description("Items to skip (paging)")] int? skip = null,
+        [Description("Continuation token for paging")] string? continuationToken = null,
+        [Description("Response shape. 'summary' (default, token-lean): { typeFullName, kind }. 'full': adds assemblyPath, matchedInterfaces[], baseTypeChain[].")] string projection = "summary",
+        [Description("Bypass cache for this request")] bool noCache = false)
+    {
+        try
+        {
+            var scope = BuildAndValidateScope(assemblyPath, additionalAssemblies);
+            if (scope.Error != null) return scope.Error;
+
+            var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
+            if (normalizedProjection != "summary" && normalizedProjection != "full")
+                return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
+
+            var scopeKey = string.Join(";", scope.Paths);
+            var saltSeed = CacheKeyHelper.Build(
+                "reverselookup.implementations.salt",
+                scopeKey, typeName, caseSensitive, includeNonPublic);
+
+            var cacheKey = CacheKeyHelper.Build(
+                "reverselookup.implementations",
+                scopeKey, typeName, caseSensitive, includeNonPublic, maxItems, continuationToken, skip, normalizedProjection);
+
+            return middleware.Execute(cacheKey, () =>
+            {
+                var options = new ReverseLookupOptions(CaseSensitive: caseSensitive, IncludeNonPublic: includeNonPublic);
+                var allHits = reverseLookup.FindImplementations(scope.Paths, typeName, options);
+
+                var defaultPageSize = runtimeOptions.GetMaxItemsForTool("FindImplementationsOf");
+                var pageSize = Math.Max(1, maxItems ?? defaultPageSize);
+                var offset = 0;
+                var salt = TokenHelper.MakeSalt(saltSeed);
+
+                if (!string.IsNullOrWhiteSpace(continuationToken))
+                {
+                    if (!TokenHelper.TryParse(continuationToken!, out offset, out var parsedSalt) || parsedSalt != salt)
+                        return JsonHelpers.Error("InvalidContinuationToken", "The continuation token is invalid or expired.");
+                }
+                else if (skip.HasValue && skip.Value > 0)
+                {
+                    offset = skip.Value;
+                }
+
+                var page = allHits.Skip(offset).Take(pageSize).ToArray();
+                string? nextToken = null;
+                var nextOffset = offset + page.Length;
+                if (nextOffset < allHits.Length) nextToken = TokenHelper.Make(nextOffset, salt);
+
+                object results = normalizedProjection == "summary"
+                    ? page.Select(h => new { typeFullName = h.TypeFullName, kind = h.Kind }).ToArray()
+                    : page.Select(h => new
+                    {
+                        typeFullName = h.TypeFullName,
+                        kind = h.Kind,
+                        assemblyPath = h.AssemblyPath,
+                        matchedInterfaces = h.MatchedInterfaces,
+                        baseTypeChain = h.BaseTypeChain
+                    }).ToArray();
+
+                var resultsJson = JsonSerializer.Serialize(results, SerializerOptions);
+                var result = new
+                {
+                    typeName,
+                    scope = scope.Paths,
+                    projection = normalizedProjection,
+                    total = allHits.Length,
+                    count = page.Length,
+                    nextToken,
+                    pagination = PaginationMetadata.Create(allHits.Length, page.Length, nextToken, resultsJson.Length),
+                    results
+                };
+                return JsonHelpers.Envelope("reverselookup.implementations", result);
+            }, noCache);
+        }
+        catch (Exception ex)
+        {
+            return JsonHelpers.Error("InternalError", $"Failed to find implementations: {ex.Message}");
+        }
+    }
+
+    [McpServerTool]
+    [Description("Finds methods whose return type matches the given type, across one or more assemblies. Returns a lean summary ({ declaringType, methodName, signature }) by default. Pass projection='full' for assemblyPath, returnType, isStatic. Open-generic match supported (e.g., 'Snapshot<>' matches methods returning 'Snapshot<int>').")]
+    public static string FindMethodsReturning(
+        IReverseLookupService reverseLookup,
+        ToolMiddleware middleware,
+        RuntimeOptions runtimeOptions,
+        [Description("Path to the primary .NET assembly file (.dll or .exe)")] string assemblyPath,
+        [Description("Return type to search for. Simple name, full name, or open-generic form accepted.")] string typeName,
+        [Description("Optional additional assembly paths to include in the search scope")] string[]? additionalAssemblies = null,
+        [Description("Case sensitive type-name matching (default: false)")] bool caseSensitive = false,
+        [Description("Include non-public methods and types (default: false)")] bool includeNonPublic = false,
+        [Description("Maximum items to return (default: 50)")] int? maxItems = null,
+        [Description("Items to skip (paging)")] int? skip = null,
+        [Description("Continuation token for paging")] string? continuationToken = null,
+        [Description("Response shape. 'summary' (default, token-lean): { declaringType, methodName, signature }. 'full': adds assemblyPath, returnType, isStatic.")] string projection = "summary",
+        [Description("Bypass cache for this request")] bool noCache = false)
+    {
+        try
+        {
+            var scope = BuildAndValidateScope(assemblyPath, additionalAssemblies);
+            if (scope.Error != null) return scope.Error;
+
+            var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
+            if (normalizedProjection != "summary" && normalizedProjection != "full")
+                return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
+
+            var scopeKey = string.Join(";", scope.Paths);
+            var saltSeed = CacheKeyHelper.Build(
+                "reverselookup.returning.salt",
+                scopeKey, typeName, caseSensitive, includeNonPublic);
+
+            var cacheKey = CacheKeyHelper.Build(
+                "reverselookup.returning",
+                scopeKey, typeName, caseSensitive, includeNonPublic, maxItems, continuationToken, skip, normalizedProjection);
+
+            return middleware.Execute(cacheKey, () =>
+            {
+                var options = new ReverseLookupOptions(CaseSensitive: caseSensitive, IncludeNonPublic: includeNonPublic);
+                var allHits = reverseLookup.FindMethodsReturning(scope.Paths, typeName, options);
+
+                var defaultPageSize = runtimeOptions.GetMaxItemsForTool("FindMethodsReturning");
+                var pageSize = Math.Max(1, maxItems ?? defaultPageSize);
+                var offset = 0;
+                var salt = TokenHelper.MakeSalt(saltSeed);
+
+                if (!string.IsNullOrWhiteSpace(continuationToken))
+                {
+                    if (!TokenHelper.TryParse(continuationToken!, out offset, out var parsedSalt) || parsedSalt != salt)
+                        return JsonHelpers.Error("InvalidContinuationToken", "The continuation token is invalid or expired.");
+                }
+                else if (skip.HasValue && skip.Value > 0)
+                {
+                    offset = skip.Value;
+                }
+
+                var page = allHits.Skip(offset).Take(pageSize).ToArray();
+                string? nextToken = null;
+                var nextOffset = offset + page.Length;
+                if (nextOffset < allHits.Length) nextToken = TokenHelper.Make(nextOffset, salt);
+
+                object results = normalizedProjection == "summary"
+                    ? page.Select(h => new
+                    {
+                        declaringType = h.DeclaringTypeFullName,
+                        methodName = h.MethodName,
+                        signature = h.Signature
+                    }).ToArray()
+                    : page.Select(h => new
+                    {
+                        declaringType = h.DeclaringTypeFullName,
+                        methodName = h.MethodName,
+                        signature = h.Signature,
+                        assemblyPath = h.AssemblyPath,
+                        returnType = h.ReturnTypeFriendlyName,
+                        isStatic = h.IsStatic
+                    }).ToArray();
+
+                var resultsJson = JsonSerializer.Serialize(results, SerializerOptions);
+                var result = new
+                {
+                    typeName,
+                    scope = scope.Paths,
+                    projection = normalizedProjection,
+                    total = allHits.Length,
+                    count = page.Length,
+                    nextToken,
+                    pagination = PaginationMetadata.Create(allHits.Length, page.Length, nextToken, resultsJson.Length),
+                    results
+                };
+                return JsonHelpers.Envelope("reverselookup.returning", result);
+            }, noCache);
+        }
+        catch (Exception ex)
+        {
+            return JsonHelpers.Error("InternalError", $"Failed to find methods by return type: {ex.Message}");
+        }
+    }
+
+    [McpServerTool]
+    [Description("Finds all references to a type across one or more assemblies: base types, implemented interfaces, method returns/parameters, field/property/event types (recurses into generic arguments). Bounded sweep with hardCap to protect against runaway scans; check truncated=true. Returns lean summary by default; projection='full' adds assemblyPath, signature, dedupeKey.")]
+    public static string FindReferencesTo(
+        IReverseLookupService reverseLookup,
+        ToolMiddleware middleware,
+        RuntimeOptions runtimeOptions,
+        [Description("Path to the primary .NET assembly file (.dll or .exe)")] string assemblyPath,
+        [Description("Type to search references to. Simple name, full name, or open-generic form accepted.")] string typeName,
+        [Description("Optional additional assembly paths to include in the search scope")] string[]? additionalAssemblies = null,
+        [Description("Case sensitive type-name matching (default: false)")] bool caseSensitive = false,
+        [Description("Include non-public members and types (default: false)")] bool includeNonPublic = false,
+        [Description("Maximum items to return (default: 25)")] int? maxItems = null,
+        [Description("Items to skip (paging)")] int? skip = null,
+        [Description("Continuation token for paging")] string? continuationToken = null,
+        [Description("Response shape. 'summary' (default, token-lean): { declaringType, memberKind, memberName, referenceKind }. 'full': adds assemblyPath, signature, dedupeKey.")] string projection = "summary",
+        [Description("Bypass cache for this request")] bool noCache = false)
+    {
+        try
+        {
+            var scope = BuildAndValidateScope(assemblyPath, additionalAssemblies);
+            if (scope.Error != null) return scope.Error;
+
+            var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
+            if (normalizedProjection != "summary" && normalizedProjection != "full")
+                return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
+
+            var scopeKey = string.Join(";", scope.Paths);
+            var saltSeed = CacheKeyHelper.Build(
+                "reverselookup.references.salt",
+                scopeKey, typeName, caseSensitive, includeNonPublic);
+
+            var cacheKey = CacheKeyHelper.Build(
+                "reverselookup.references",
+                scopeKey, typeName, caseSensitive, includeNonPublic, maxItems, continuationToken, skip, normalizedProjection);
+
+            return middleware.Execute(cacheKey, () =>
+            {
+                var defaultPageSize = runtimeOptions.GetMaxItemsForTool("FindReferencesTo");
+                var pageSize = Math.Max(1, maxItems ?? defaultPageSize);
+                var hardCap = Math.Max(pageSize * 4, 500);
+                var options = new ReverseLookupOptions(
+                    CaseSensitive: caseSensitive,
+                    IncludeNonPublic: includeNonPublic,
+                    HardCap: hardCap);
+
+                var scanResult = reverseLookup.FindReferences(scope.Paths, typeName, options);
+                var allHits = scanResult.Hits;
+
+                var offset = 0;
+                var salt = TokenHelper.MakeSalt(saltSeed);
+
+                if (!string.IsNullOrWhiteSpace(continuationToken))
+                {
+                    if (!TokenHelper.TryParse(continuationToken!, out offset, out var parsedSalt) || parsedSalt != salt)
+                        return JsonHelpers.Error("InvalidContinuationToken", "The continuation token is invalid or expired.");
+                }
+                else if (skip.HasValue && skip.Value > 0)
+                {
+                    offset = skip.Value;
+                }
+
+                var page = allHits.Skip(offset).Take(pageSize).ToArray();
+                string? nextToken = null;
+                var nextOffset = offset + page.Length;
+                if (nextOffset < allHits.Length) nextToken = TokenHelper.Make(nextOffset, salt);
+
+                object results = normalizedProjection == "summary"
+                    ? page.Select(h => new
+                    {
+                        declaringType = h.DeclaringTypeFullName,
+                        memberKind = h.MemberKind,
+                        memberName = h.MemberName,
+                        referenceKind = h.ReferenceKind
+                    }).ToArray()
+                    : page.Select(h => new
+                    {
+                        declaringType = h.DeclaringTypeFullName,
+                        memberKind = h.MemberKind,
+                        memberName = h.MemberName,
+                        referenceKind = h.ReferenceKind,
+                        assemblyPath = h.AssemblyPath,
+                        signature = h.Signature,
+                        dedupeKey = h.DedupeKey
+                    }).ToArray();
+
+                var resultsJson = JsonSerializer.Serialize(results, SerializerOptions);
+                var result = new
+                {
+                    typeName,
+                    scope = scope.Paths,
+                    projection = normalizedProjection,
+                    total = allHits.Length,
+                    count = page.Length,
+                    truncated = scanResult.Truncated,
+                    hardCap,
+                    nextToken,
+                    pagination = PaginationMetadata.Create(allHits.Length, page.Length, nextToken, resultsJson.Length),
+                    results
+                };
+
+                var sizeError = ResponseSizeHelper.ValidateResponseSize(result, "FindReferencesTo");
+                if (sizeError != null) return sizeError;
+
+                return JsonHelpers.Envelope("reverselookup.references", result);
+            }, noCache);
+        }
+        catch (Exception ex)
+        {
+            return JsonHelpers.Error("InternalError", $"Failed to find references: {ex.Message}");
+        }
+    }
+
+    private readonly struct ScopeResult
+    {
+        public string[] Paths { get; init; }
+        public string? Error { get; init; }
+    }
+
+    private static ScopeResult BuildAndValidateScope(string assemblyPath, string[]? additionalAssemblies)
+    {
+        if (string.IsNullOrWhiteSpace(assemblyPath))
+            return new ScopeResult { Error = JsonHelpers.Error("InvalidArgument", "assemblyPath is required") };
+        if (!File.Exists(assemblyPath))
+            return new ScopeResult { Error = JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}") };
+
+        var paths = new List<string> { assemblyPath };
+        if (additionalAssemblies != null)
+        {
+            foreach (var extra in additionalAssemblies)
+            {
+                if (string.IsNullOrWhiteSpace(extra)) continue;
+                if (!File.Exists(extra))
+                    return new ScopeResult { Error = JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {extra}") };
+                paths.Add(extra);
+            }
+        }
+        return new ScopeResult { Paths = paths.ToArray() };
+    }
+}

--- a/src/unit-tests/ReverseLookupFixtures.cs
+++ b/src/unit-tests/ReverseLookupFixtures.cs
@@ -1,0 +1,53 @@
+namespace Sherlock.MCP.Tests.ReverseLookupFixtures;
+
+public interface ISampleEventReader
+{
+    void Read();
+}
+
+public interface ISampleEventReader<T> : ISampleEventReader
+{
+    T? Next();
+}
+
+public class ConcreteReader : ISampleEventReader
+{
+    public void Read() { }
+}
+
+public class TypedReader : ISampleEventReader<RecordedEvent>
+{
+    public void Read() { }
+    public RecordedEvent? Next() => null;
+}
+
+public class FakeEventReader : ConcreteReader
+{
+}
+
+public record RecordedEvent(string Name, long Position);
+
+public class Snapshot<T>
+{
+    public T? Value { get; init; }
+}
+
+public class SnapshotFactory
+{
+    public Snapshot<int> CreateIntSnapshot() => new() { Value = 0 };
+    public Snapshot<RecordedEvent> CreateEventSnapshot() => new();
+    public int GetCount() => 0;
+    public Task<Snapshot<string>> CreateAsync() => Task.FromResult(new Snapshot<string>());
+}
+
+public class EventStore
+{
+    public RecordedEvent? LastEvent;
+    public List<RecordedEvent> All { get; } = new();
+    public Snapshot<RecordedEvent>? CurrentSnapshot { get; set; }
+
+    public void Append(RecordedEvent evt) { }
+    public RecordedEvent? GetAt(int index) => null;
+    public event Action<RecordedEvent>? OnAppended;
+    public void RaiseOnAppended(RecordedEvent evt) => OnAppended?.Invoke(evt);
+}

--- a/src/unit-tests/ReverseLookupServiceTests.cs
+++ b/src/unit-tests/ReverseLookupServiceTests.cs
@@ -1,0 +1,197 @@
+using System.Reflection;
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Contracts.ReverseLookup;
+using Sherlock.MCP.Tests.ReverseLookupFixtures;
+
+namespace Sherlock.MCP.Tests;
+
+public class ReverseLookupServiceTests
+{
+    private readonly IReverseLookupService _svc = new ReverseLookupService();
+    private readonly string _testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+    private readonly ReverseLookupOptions _defaultOptions = new();
+
+    [Fact]
+    public void FindImplementations_FindsInterfaceImplementers()
+    {
+        var hits = _svc.FindImplementations(
+            [_testAssemblyPath],
+            "ISampleEventReader",
+            _defaultOptions);
+
+        Assert.Contains(hits, h => h.TypeFullName == typeof(ConcreteReader).FullName);
+        Assert.Contains(hits, h => h.TypeFullName == typeof(TypedReader).FullName);
+        Assert.All(hits.Where(h => h.TypeFullName == typeof(ConcreteReader).FullName),
+            h => Assert.Equal("interface", h.Kind));
+    }
+
+    [Fact]
+    public void FindImplementations_TransitiveThroughBaseClass()
+    {
+        var hits = _svc.FindImplementations(
+            [_testAssemblyPath],
+            "ISampleEventReader",
+            _defaultOptions);
+
+        Assert.Contains(hits, h => h.TypeFullName == typeof(FakeEventReader).FullName);
+    }
+
+    [Fact]
+    public void FindImplementations_FindsBaseTypeDescendants()
+    {
+        var hits = _svc.FindImplementations(
+            [_testAssemblyPath],
+            "ConcreteReader",
+            _defaultOptions);
+
+        Assert.Contains(hits, h => h.TypeFullName == typeof(FakeEventReader).FullName && h.Kind == "baseType");
+    }
+
+    [Fact]
+    public void FindImplementations_OpenGenericInterface_MatchesClosedForm()
+    {
+        var hits = _svc.FindImplementations(
+            [_testAssemblyPath],
+            "ISampleEventReader<>",
+            _defaultOptions);
+
+        Assert.Contains(hits, h => h.TypeFullName == typeof(TypedReader).FullName);
+    }
+
+    [Fact]
+    public void FindMethodsReturning_ClosedGeneric_MatchesClosedReturn()
+    {
+        var hits = _svc.FindMethodsReturning(
+            [_testAssemblyPath],
+            "Snapshot",
+            _defaultOptions);
+
+        Assert.Contains(hits, h => h.MethodName == nameof(SnapshotFactory.CreateIntSnapshot));
+        Assert.Contains(hits, h => h.MethodName == nameof(SnapshotFactory.CreateEventSnapshot));
+    }
+
+    [Fact]
+    public void FindMethodsReturning_OpenGeneric_MatchesClosedReturn()
+    {
+        var hits = _svc.FindMethodsReturning(
+            [_testAssemblyPath],
+            "Snapshot<>",
+            _defaultOptions);
+
+        Assert.Contains(hits, h => h.MethodName == nameof(SnapshotFactory.CreateIntSnapshot));
+    }
+
+    [Fact]
+    public void FindMethodsReturning_BuiltInAlias_MatchesPrimitiveReturn()
+    {
+        var hits = _svc.FindMethodsReturning(
+            [_testAssemblyPath],
+            "int",
+            _defaultOptions);
+
+        Assert.Contains(hits, h => h.MethodName == nameof(SnapshotFactory.GetCount));
+    }
+
+    [Fact]
+    public void FindMethodsReturning_IncludesSignatureAndFriendlyName()
+    {
+        var hits = _svc.FindMethodsReturning(
+            [_testAssemblyPath],
+            "Snapshot",
+            _defaultOptions);
+
+        var hit = hits.First(h => h.MethodName == nameof(SnapshotFactory.CreateIntSnapshot));
+        Assert.Contains("Snapshot", hit.Signature);
+        Assert.Contains("CreateIntSnapshot", hit.Signature);
+        Assert.Contains("Snapshot", hit.ReturnTypeFriendlyName);
+    }
+
+    [Fact]
+    public void FindReferences_EmitsAllReferenceKinds()
+    {
+        var result = _svc.FindReferences(
+            [_testAssemblyPath],
+            "RecordedEvent",
+            _defaultOptions);
+
+        var declaring = typeof(EventStore).FullName!;
+        var hits = result.Hits.Where(h => h.DeclaringTypeFullName == declaring).ToArray();
+
+        Assert.Contains(hits, h => h.ReferenceKind == "field" && h.MemberName == nameof(EventStore.LastEvent));
+        Assert.Contains(hits, h => h.ReferenceKind == "property" && h.MemberName == nameof(EventStore.All));
+        Assert.Contains(hits, h => h.ReferenceKind == "property" && h.MemberName == nameof(EventStore.CurrentSnapshot));
+        Assert.Contains(hits, h => h.ReferenceKind == "parameter" && h.MemberName == nameof(EventStore.Append));
+        Assert.Contains(hits, h => h.ReferenceKind == "return" && h.MemberName == nameof(EventStore.GetAt));
+        Assert.Contains(hits, h => h.ReferenceKind == "event" && h.MemberName == nameof(EventStore.OnAppended));
+    }
+
+    [Fact]
+    public void FindReferences_IncludesInterfaceAndBaseTypeHits()
+    {
+        var result = _svc.FindReferences(
+            [_testAssemblyPath],
+            "ISampleEventReader",
+            _defaultOptions);
+
+        Assert.Contains(result.Hits, h =>
+            h.DeclaringTypeFullName == typeof(ConcreteReader).FullName && h.ReferenceKind == "interface");
+    }
+
+    [Fact]
+    public void FindReferences_RecursesThroughGenericArguments()
+    {
+        var result = _svc.FindReferences(
+            [_testAssemblyPath],
+            "RecordedEvent",
+            _defaultOptions);
+
+        Assert.Contains(result.Hits, h =>
+            h.DeclaringTypeFullName == typeof(EventStore).FullName
+            && h.ReferenceKind == "property"
+            && h.MemberName == nameof(EventStore.All));
+        Assert.Contains(result.Hits, h =>
+            h.DeclaringTypeFullName == typeof(EventStore).FullName
+            && h.ReferenceKind == "property"
+            && h.MemberName == nameof(EventStore.CurrentSnapshot));
+        Assert.Contains(result.Hits, h =>
+            h.DeclaringTypeFullName == typeof(EventStore).FullName
+            && h.ReferenceKind == "event"
+            && h.MemberName == nameof(EventStore.OnAppended));
+    }
+
+    [Fact]
+    public void FindReferences_HonorsHardCap()
+    {
+        var opts = new ReverseLookupOptions(HardCap: 2);
+        var result = _svc.FindReferences(
+            [_testAssemblyPath],
+            "RecordedEvent",
+            opts);
+
+        Assert.True(result.Hits.Length <= 2);
+        Assert.True(result.Truncated);
+    }
+
+    [Fact]
+    public void FindReferences_DedupeKeyIsStable()
+    {
+        var result = _svc.FindReferences(
+            [_testAssemblyPath],
+            "RecordedEvent",
+            _defaultOptions);
+
+        var keys = result.Hits.Select(h => h.DedupeKey).ToArray();
+        Assert.Equal(keys.Length, keys.Distinct().Count());
+    }
+
+    [Fact]
+    public void MissingAssemblyPath_IsSkippedSilently()
+    {
+        var hits = _svc.FindImplementations(
+            ["/tmp/does-not-exist.dll"],
+            "IDisposable",
+            _defaultOptions);
+
+        Assert.Empty(hits);
+    }
+}

--- a/src/unit-tests/ReverseLookupToolsTests.cs
+++ b/src/unit-tests/ReverseLookupToolsTests.cs
@@ -171,7 +171,7 @@ public class ReverseLookupToolsTests
     }
 
     [Fact]
-    public void FindReferencesTo_SmallMaxItems_TruncatedTrueWhenHardCapHit()
+    public void FindReferencesTo_SmallMaxItems_ReportsFloor500HardCap()
     {
         var result = ReverseLookupTools.FindReferencesTo(
             _svc, _middleware, _runtimeOptions,
@@ -180,6 +180,19 @@ public class ReverseLookupToolsTests
         var data = JsonDocument.Parse(result).RootElement.GetProperty("data");
         var hardCap = data.GetProperty("hardCap").GetInt32();
         Assert.Equal(500, hardCap);
+        Assert.False(data.GetProperty("truncated").GetBoolean(),
+            "Small test assembly should not exceed the 500-hit floor.");
+    }
+
+    [Fact]
+    public void FindReferencesTo_LargeMaxItems_ScalesHardCapAboveFloor()
+    {
+        var result = ReverseLookupTools.FindReferencesTo(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "RecordedEvent", maxItems: 200, noCache: true);
+
+        var data = JsonDocument.Parse(result).RootElement.GetProperty("data");
+        Assert.Equal(800, data.GetProperty("hardCap").GetInt32());
     }
 
     [Fact]

--- a/src/unit-tests/ReverseLookupToolsTests.cs
+++ b/src/unit-tests/ReverseLookupToolsTests.cs
@@ -1,0 +1,206 @@
+using System.Reflection;
+using System.Text.Json;
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Caching;
+using Sherlock.MCP.Runtime.Telemetry;
+using Sherlock.MCP.Server.Middleware;
+using Sherlock.MCP.Server.Tools;
+using Sherlock.MCP.Tests.ReverseLookupFixtures;
+
+namespace Sherlock.MCP.Tests;
+
+public class ReverseLookupToolsTests
+{
+    private readonly IReverseLookupService _svc = new ReverseLookupService();
+    private readonly RuntimeOptions _runtimeOptions = new();
+    private readonly ToolMiddleware _middleware;
+    private readonly string _testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+    public ReverseLookupToolsTests()
+    {
+        var cache = new InMemoryToolResponseCache();
+        var telemetry = new NoopTelemetry();
+        _middleware = new ToolMiddleware(cache, telemetry, _runtimeOptions);
+    }
+
+    [Fact]
+    public void FindImplementationsOf_Envelope_AndSummaryShape()
+    {
+        var result = ReverseLookupTools.FindImplementationsOf(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "ISampleEventReader", noCache: true);
+
+        Assert.DoesNotContain("\"error\"", result);
+        var doc = JsonDocument.Parse(result);
+        Assert.Equal("reverselookup.implementations", doc.RootElement.GetProperty("kind").GetString());
+
+        var data = doc.RootElement.GetProperty("data");
+        Assert.Equal("summary", data.GetProperty("projection").GetString());
+        Assert.True(data.GetProperty("total").GetInt32() > 0);
+
+        var results = data.GetProperty("results");
+        Assert.True(results.GetArrayLength() > 0);
+        var first = results[0];
+        Assert.True(first.TryGetProperty("typeFullName", out _));
+        Assert.True(first.TryGetProperty("kind", out _));
+        Assert.False(first.TryGetProperty("matchedInterfaces", out _),
+            "Summary should not include matchedInterfaces");
+    }
+
+    [Fact]
+    public void FindImplementationsOf_FullProjection_IncludesHeavyFields()
+    {
+        var result = ReverseLookupTools.FindImplementationsOf(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "ISampleEventReader", projection: "full", noCache: true);
+
+        Assert.DoesNotContain("\"error\"", result);
+        var data = JsonDocument.Parse(result).RootElement.GetProperty("data");
+        Assert.Equal("full", data.GetProperty("projection").GetString());
+        var first = data.GetProperty("results")[0];
+        Assert.True(first.TryGetProperty("matchedInterfaces", out _));
+        Assert.True(first.TryGetProperty("baseTypeChain", out _));
+        Assert.True(first.TryGetProperty("assemblyPath", out _));
+    }
+
+    [Fact]
+    public void FindImplementationsOf_InvalidProjection_ReturnsError()
+    {
+        var result = ReverseLookupTools.FindImplementationsOf(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "ISampleEventReader", projection: "partial", noCache: true);
+
+        Assert.Contains("InvalidProjection", result);
+    }
+
+    [Fact]
+    public void FindImplementationsOf_AssemblyNotFound_ReturnsError()
+    {
+        var result = ReverseLookupTools.FindImplementationsOf(
+            _svc, _middleware, _runtimeOptions,
+            "/tmp/does-not-exist.dll", "ISampleEventReader", noCache: true);
+
+        Assert.Contains("AssemblyNotFound", result);
+    }
+
+    [Fact]
+    public void FindImplementationsOf_MissingAdditionalAssembly_ReturnsError()
+    {
+        var result = ReverseLookupTools.FindImplementationsOf(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "ISampleEventReader",
+            additionalAssemblies: new[] { "/tmp/also-missing.dll" },
+            noCache: true);
+
+        Assert.Contains("AssemblyNotFound", result);
+        Assert.Contains("also-missing", result);
+    }
+
+    [Fact]
+    public void FindImplementationsOf_ContinuationToken_RoundTrips()
+    {
+        var page1 = ReverseLookupTools.FindImplementationsOf(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "ISampleEventReader", maxItems: 1, noCache: true);
+
+        Assert.DoesNotContain("\"error\"", page1);
+        var page1Data = JsonDocument.Parse(page1).RootElement.GetProperty("data");
+        if (page1Data.GetProperty("total").GetInt32() < 2) return;
+
+        var nextToken = page1Data.GetProperty("nextToken").GetString();
+        Assert.False(string.IsNullOrEmpty(nextToken));
+
+        var page2 = ReverseLookupTools.FindImplementationsOf(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "ISampleEventReader",
+            maxItems: 1, continuationToken: nextToken, noCache: true);
+
+        Assert.DoesNotContain("InvalidContinuationToken", page2);
+        Assert.DoesNotContain("\"error\"", page2);
+        Assert.Equal(1, JsonDocument.Parse(page2).RootElement.GetProperty("data").GetProperty("count").GetInt32());
+    }
+
+    [Fact]
+    public void FindMethodsReturning_Envelope_Summary()
+    {
+        var result = ReverseLookupTools.FindMethodsReturning(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "Snapshot", noCache: true);
+
+        Assert.DoesNotContain("\"error\"", result);
+        var doc = JsonDocument.Parse(result);
+        Assert.Equal("reverselookup.returning", doc.RootElement.GetProperty("kind").GetString());
+
+        var data = doc.RootElement.GetProperty("data");
+        Assert.True(data.GetProperty("total").GetInt32() > 0);
+        var first = data.GetProperty("results")[0];
+        Assert.True(first.TryGetProperty("declaringType", out _));
+        Assert.True(first.TryGetProperty("methodName", out _));
+        Assert.True(first.TryGetProperty("signature", out _));
+        Assert.False(first.TryGetProperty("isStatic", out _));
+    }
+
+    [Fact]
+    public void FindMethodsReturning_FullIncludesExtraFields()
+    {
+        var result = ReverseLookupTools.FindMethodsReturning(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "Snapshot", projection: "full", noCache: true);
+
+        var data = JsonDocument.Parse(result).RootElement.GetProperty("data");
+        var first = data.GetProperty("results")[0];
+        Assert.True(first.TryGetProperty("returnType", out _));
+        Assert.True(first.TryGetProperty("isStatic", out _));
+        Assert.True(first.TryGetProperty("assemblyPath", out _));
+    }
+
+    [Fact]
+    public void FindReferencesTo_Envelope_IncludesTruncatedFlag()
+    {
+        var result = ReverseLookupTools.FindReferencesTo(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "RecordedEvent", noCache: true);
+
+        Assert.DoesNotContain("\"error\"", result);
+        var doc = JsonDocument.Parse(result);
+        Assert.Equal("reverselookup.references", doc.RootElement.GetProperty("kind").GetString());
+
+        var data = doc.RootElement.GetProperty("data");
+        Assert.True(data.TryGetProperty("truncated", out _));
+        Assert.True(data.TryGetProperty("hardCap", out _));
+    }
+
+    [Fact]
+    public void FindReferencesTo_SmallMaxItems_TruncatedTrueWhenHardCapHit()
+    {
+        var result = ReverseLookupTools.FindReferencesTo(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "RecordedEvent", maxItems: 1, noCache: true);
+
+        var data = JsonDocument.Parse(result).RootElement.GetProperty("data");
+        var hardCap = data.GetProperty("hardCap").GetInt32();
+        Assert.Equal(500, hardCap);
+    }
+
+    [Fact]
+    public void FindReferencesTo_ContinuationToken_RoundTrips()
+    {
+        var page1 = ReverseLookupTools.FindReferencesTo(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "RecordedEvent", maxItems: 1, noCache: true);
+
+        var page1Data = JsonDocument.Parse(page1).RootElement.GetProperty("data");
+        if (page1Data.GetProperty("total").GetInt32() < 2) return;
+
+        var nextToken = page1Data.GetProperty("nextToken").GetString();
+        Assert.False(string.IsNullOrEmpty(nextToken));
+
+        var page2 = ReverseLookupTools.FindReferencesTo(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "RecordedEvent",
+            maxItems: 1, continuationToken: nextToken, noCache: true);
+
+        Assert.DoesNotContain("InvalidContinuationToken", page2);
+        Assert.Equal(1, JsonDocument.Parse(page2).RootElement.GetProperty("data").GetProperty("count").GetInt32());
+    }
+}

--- a/src/unit-tests/TypeNameMatcherTests.cs
+++ b/src/unit-tests/TypeNameMatcherTests.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using Sherlock.MCP.Runtime;
+
+namespace Sherlock.MCP.Tests;
+
+public class TypeNameMatcherTests
+{
+    [Fact]
+    public void Matches_SimpleName() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(string), "String"));
+
+    [Fact]
+    public void Matches_FullName() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(string), "System.String"));
+
+    [Fact]
+    public void Matches_BuiltInAlias() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(int), "int"));
+
+    [Fact]
+    public void Matches_BuiltInAlias_Bool() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(bool), "bool"));
+
+    [Fact]
+    public void Matches_OpenGeneric_BareName() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(List<>), "List"));
+
+    [Fact]
+    public void Matches_ConstructedGeneric_BareName() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(List<int>), "List"));
+
+    [Fact]
+    public void Matches_ConstructedGeneric_AngleBracketOpen() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(List<int>), "List<>"));
+
+    [Fact]
+    public void Matches_ConstructedGeneric_AngleBracketWithTypeParam() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(List<int>), "List<T>"));
+
+    [Fact]
+    public void Matches_ConstructedGeneric_BacktickArity() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(List<int>), "List`1"));
+
+    [Fact]
+    public void Matches_ConstructedGeneric_FullNameWithArity() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(List<int>), "System.Collections.Generic.List`1"));
+
+    [Fact]
+    public void Matches_NestedType_PlusSeparator() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(Outer.Inner), "Outer+Inner"));
+
+    [Fact]
+    public void Matches_NestedType_DotSeparator() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(Outer.Inner), "Outer.Inner"));
+
+    [Fact]
+    public void Matches_Array_UnwrapsToElement() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(int[]), "int"));
+
+    [Fact]
+    public void Matches_MultiDimArray_UnwrapsToElement() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(string[,]), "String"));
+
+    [Fact]
+    public void Matches_ByRef_UnwrapsToElement()
+    {
+        var byRefInt = typeof(int).MakeByRefType();
+        Assert.True(TypeNameMatcher.Matches(byRefInt, "int"));
+    }
+
+    [Fact]
+    public void Matches_Pointer_UnwrapsToElement()
+    {
+        var ptrInt = typeof(int).MakePointerType();
+        Assert.True(TypeNameMatcher.Matches(ptrInt, "Int32"));
+    }
+
+    [Fact]
+    public void Matches_Nullable_QuestionMarkSyntax() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(int?), "int?"));
+
+    [Fact]
+    public void Matches_Nullable_ExplicitNullableSyntax() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(int?), "Nullable<int>"));
+
+    [Fact]
+    public void Matches_Nullable_BareName() =>
+        Assert.True(TypeNameMatcher.Matches(typeof(int?), "Nullable"));
+
+    [Fact]
+    public void Matches_AssemblyQualifiedName_Stripped() =>
+        Assert.True(TypeNameMatcher.Matches(
+            typeof(List<int>),
+            "System.Collections.Generic.List`1, System.Private.CoreLib, Version=7.0.0.0"));
+
+    [Fact]
+    public void Matches_GenericParameter_AlwaysFalse()
+    {
+        var listOpen = typeof(List<>);
+        var tParam = listOpen.GetGenericArguments()[0];
+        Assert.False(TypeNameMatcher.Matches(tParam, "T"));
+        Assert.False(TypeNameMatcher.Matches(tParam, "int"));
+    }
+
+    [Fact]
+    public void Matches_CaseSensitive_Strict()
+    {
+        Assert.False(TypeNameMatcher.Matches(typeof(string), "STRING", caseSensitive: true));
+        Assert.True(TypeNameMatcher.Matches(typeof(string), "String", caseSensitive: true));
+    }
+
+    [Fact]
+    public void Matches_CaseInsensitive_Default()
+    {
+        Assert.True(TypeNameMatcher.Matches(typeof(string), "STRING"));
+        Assert.True(TypeNameMatcher.Matches(typeof(string), "string"));
+    }
+
+    [Fact]
+    public void Matches_NullCandidate_False() =>
+        Assert.False(TypeNameMatcher.Matches((Type?)null, "int"));
+
+    [Fact]
+    public void Matches_NullOrEmptyUserName_False()
+    {
+        Assert.False(TypeNameMatcher.Matches(typeof(int), null));
+        Assert.False(TypeNameMatcher.Matches(typeof(int), ""));
+        Assert.False(TypeNameMatcher.Matches(typeof(int), "   "));
+    }
+
+    [Fact]
+    public void Matches_DifferentType_False()
+    {
+        Assert.False(TypeNameMatcher.Matches(typeof(int), "string"));
+        Assert.False(TypeNameMatcher.Matches(typeof(List<int>), "Dictionary"));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #22. Adds three new MCP tools for reverse cross-reference queries across one or more assemblies:

- **`FindImplementationsOf`** — types whose interfaces (transitive) or base-type chain match the target. Kind = `interface` or `baseType`.
- **`FindMethodsReturning`** — methods whose return type matches the target. Supports open-generic match (`Snapshot<>` matches `Snapshot<int>`).
- **`FindReferencesTo`** — broader sweep across base types, interfaces, method returns/parameters, field/property/event types; recurses into generic arguments. Bounded by a hard scan cap (default `max(maxItems*4, 500)`) with `truncated: true` in the response when hit.

All three follow the existing pagination/projection/caching conventions (`summary` vs `full`, token-lean defaults, stable-salt continuation tokens, ToolMiddleware caching).

New `TypeNameMatcher` (in `src/runtime/`) normalizes simple, full, open-generic (`Foo<>`, `Foo<T>`, `Foo\`1`), nested (`Outer+Inner` or `Outer.Inner`), array/byref/pointer, nullable (`int?`), assembly-qualified, and built-in alias (`int`, `string`) forms. Generic-parameter guard prevents noise (unbound `T` never matches).

New `IReverseLookupService` encapsulates scan logic; per-assembly inspection contexts with try/catch-and-continue for metadata-only resolution failures. Hit records live in `Contracts/ReverseLookup/` and include a stable `DedupeKey` for callers that want to dedupe.

## Test plan

- [x] `TypeNameMatcherTests` (26 tests) — every normalization edge case
- [x] `ReverseLookupServiceTests` (14 tests) — fixture-driven scan semantics including hard-cap and generic-arg recursion
- [x] `ReverseLookupToolsTests` (11 tests) — envelope shape, projection switch, `InvalidProjection` / `AssemblyNotFound` errors, continuation round-trip, truncated flag
- [x] Full solution: `dotnet build` clean, `dotnet test` 97/97 passing on net8.0 and net10.0
- [ ] Manual smoke (after merge + MCP server restart): `find_implementations_of` / `find_methods_returning` / `find_references_to` against a real SDK DLL

## Notes

- Docs updated: `CLAUDE.md` and `README.md` bump the tool count to 31+ and add a Reverse Lookup category; `CHANGELOG.md` adds an Unreleased entry.
- Per-assembly `MetadataLoadContext` per the Plan-agent review — unified multi-context resolution is a known deferral documented in the plan. Typical cases (same directory, runtime dir) are already covered by `MetadataResolverFactory`.