### PR TITLE
feat(tools): add FindAssemblyByNugetPackage for direct NuGet cache lookup

### DIFF
--- a/src/runtime/Contracts/ProjectAnalysis/NugetAssemblyLookup.cs
+++ b/src/runtime/Contracts/ProjectAnalysis/NugetAssemblyLookup.cs
@@ -1,0 +1,21 @@
+namespace Sherlock.MCP.Runtime.Contracts.ProjectAnalysis;
+
+public record NugetAssemblyLookup(
+    string PackageId,
+    string? RequestedVersion,
+    string? RequestedTfm,
+    string? ResolvedVersion,
+    string? ResolvedTfm,
+    string CacheRoot,
+    string? FoundAssembly,
+    string[] AvailableVersions,
+    string[] AvailableTfms,
+    NugetLookupFailure? Failure
+);
+
+public enum NugetLookupFailure
+{
+    PackageNotFound,
+    VersionNotFound,
+    AssemblyNotFound
+}

--- a/src/runtime/IProjectAnalysisService.cs
+++ b/src/runtime/IProjectAnalysisService.cs
@@ -9,5 +9,6 @@ public interface IProjectAnalysisService
     public Task<string[]> GetProjectOutputPathsAsync(string projectFilePath, string? configuration = null);
     public Task<PackageReference[]> ResolvePackageReferencesAsync(string projectFilePath, string? packageName = null);
     public Task<RuntimeDependency[]> FindDepsJsonFilesAsync(string projectFilePath, string configuration = "Debug");
+    public Task<NugetAssemblyLookup> FindAssemblyInNugetCacheAsync(string packageId, string? version = null, string? tfm = null);
 }
 

--- a/src/runtime/ProjectAnalysisService.cs
+++ b/src/runtime/ProjectAnalysisService.cs
@@ -169,6 +169,9 @@ public class ProjectAnalysisService : IProjectAnalysisService
 
     public Task<NugetAssemblyLookup> FindAssemblyInNugetCacheAsync(string packageId, string? version = null, string? tfm = null)
     {
+        ValidatePackageId(packageId);
+        ValidateOptionalPathSegment(version, nameof(version));
+        ValidateOptionalPathSegment(tfm, nameof(tfm));
         var cacheRoot = GetNugetCacheRoot();
         var packageDir = Path.Combine(cacheRoot, packageId.ToLowerInvariant());
         if (!Directory.Exists(packageDir))
@@ -289,6 +292,42 @@ public class ProjectAnalysisService : IProjectAnalysisService
             Failure: foundAssembly is null ? NugetLookupFailure.AssemblyNotFound : null));
     }
 
+    private static readonly char[] PathSeparators = { '/', '\\' };
+
+    private static void ValidatePackageId(string packageId)
+    {
+        if (string.IsNullOrWhiteSpace(packageId))
+            throw new ArgumentException("packageId must be provided.", nameof(packageId));
+        ValidatePathSegment(packageId, nameof(packageId));
+        foreach (var ch in packageId)
+            if (!IsValidNugetIdChar(ch))
+                throw new ArgumentException($"packageId contains invalid character '{ch}'. NuGet ids allow letters, digits, '.', '_', and '-'.", nameof(packageId));
+    }
+
+    private static void ValidateOptionalPathSegment(string? value, string paramName)
+    {
+        if (value is null)
+            return;
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException($"{paramName} must not be whitespace.", paramName);
+        ValidatePathSegment(value, paramName);
+    }
+
+    private static void ValidatePathSegment(string value, string paramName)
+    {
+        if (Path.IsPathRooted(value))
+            throw new ArgumentException($"{paramName} must not be a rooted path.", paramName);
+        if (value.IndexOfAny(PathSeparators) >= 0)
+            throw new ArgumentException($"{paramName} must not contain path separators.", paramName);
+        if (value == ".." || value == "." || value.Contains(".."))
+            throw new ArgumentException($"{paramName} must not contain parent-directory segments.", paramName);
+        if (value.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            throw new ArgumentException($"{paramName} contains invalid path characters.", paramName);
+    }
+
+    private static bool IsValidNugetIdChar(char ch) =>
+        char.IsLetterOrDigit(ch) || ch == '.' || ch == '_' || ch == '-';
+
     private static string GetNugetCacheRoot()
     {
         var overridePath = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
@@ -313,9 +352,9 @@ public class ProjectAnalysisService : IProjectAnalysisService
 
     private static Version? TryParseVersion(string raw)
     {
-        var dash = raw.IndexOf('-');
-        var core = dash >= 0 ? raw[..dash] : raw;
-        return Version.TryParse(core, out var v) ? v : null;
+        if (raw.Contains('-'))
+            return null;
+        return Version.TryParse(raw, out var v) ? v : null;
     }
 
     private static string[] SortVersionsDescending(string[] versions)
@@ -359,13 +398,35 @@ public class ProjectAnalysisService : IProjectAnalysisService
         if (lower.StartsWith("net") && !lower.StartsWith("netstandard") && !lower.StartsWith("netcoreapp") && !lower.Contains("framework"))
         {
             var rest = lower[3..];
+            if (IsFrameworkStyleTfm(rest))
+                return (3, ParseFrameworkStyleVersion(rest));
             return (0, TryParseVersion(rest) ?? new Version(0, 0));
         }
         if (lower.StartsWith("netcoreapp"))
             return (1, TryParseVersion(lower[10..]) ?? new Version(0, 0));
         if (lower.StartsWith("netstandard"))
             return (2, TryParseVersion(lower[11..]) ?? new Version(0, 0));
-        return (3, new Version(0, 0));
+        return (4, new Version(0, 0));
+    }
+
+    private static bool IsFrameworkStyleTfm(string rest)
+    {
+        if (rest.Length is not (2 or 3))
+            return false;
+        foreach (var ch in rest)
+            if (!char.IsDigit(ch))
+                return false;
+        return rest[0] is >= '1' and <= '4';
+    }
+
+    private static Version ParseFrameworkStyleVersion(string rest)
+    {
+        var major = rest[0] - '0';
+        var minor = rest[1] - '0';
+        if (rest.Length == 2)
+            return new Version(major, minor);
+        var patch = rest[2] - '0';
+        return new Version(major, minor, patch);
     }
 
     private static string? PickAssemblyForPackage(string[] dlls, string packageId)

--- a/src/runtime/ProjectAnalysisService.cs
+++ b/src/runtime/ProjectAnalysisService.cs
@@ -167,6 +167,217 @@ public class ProjectAnalysisService : IProjectAnalysisService
         return dependencies.ToArray();
     }
 
+    public Task<NugetAssemblyLookup> FindAssemblyInNugetCacheAsync(string packageId, string? version = null, string? tfm = null)
+    {
+        var cacheRoot = GetNugetCacheRoot();
+        var packageDir = Path.Combine(cacheRoot, packageId.ToLowerInvariant());
+        if (!Directory.Exists(packageDir))
+        {
+            return Task.FromResult(new NugetAssemblyLookup(
+                packageId,
+                version,
+                tfm,
+                ResolvedVersion: null,
+                ResolvedTfm: null,
+                cacheRoot,
+                FoundAssembly: null,
+                AvailableVersions: Array.Empty<string>(),
+                AvailableTfms: Array.Empty<string>(),
+                Failure: NugetLookupFailure.PackageNotFound));
+        }
+
+        var availableVersions = Directory.GetDirectories(packageDir)
+            .Select(Path.GetFileName)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .Cast<string>()
+            .ToArray();
+
+        string? resolvedVersion;
+        if (version is not null)
+        {
+            resolvedVersion = availableVersions
+                .FirstOrDefault(v => v.Equals(version, StringComparison.OrdinalIgnoreCase));
+            if (resolvedVersion is null)
+            {
+                return Task.FromResult(new NugetAssemblyLookup(
+                    packageId,
+                    version,
+                    tfm,
+                    ResolvedVersion: null,
+                    ResolvedTfm: null,
+                    cacheRoot,
+                    FoundAssembly: null,
+                    AvailableVersions: SortVersionsDescending(availableVersions),
+                    AvailableTfms: Array.Empty<string>(),
+                    Failure: NugetLookupFailure.VersionNotFound));
+            }
+        }
+        else
+        {
+            resolvedVersion = PickHighestVersion(availableVersions);
+            if (resolvedVersion is null)
+            {
+                return Task.FromResult(new NugetAssemblyLookup(
+                    packageId,
+                    version,
+                    tfm,
+                    ResolvedVersion: null,
+                    ResolvedTfm: null,
+                    cacheRoot,
+                    FoundAssembly: null,
+                    AvailableVersions: Array.Empty<string>(),
+                    AvailableTfms: Array.Empty<string>(),
+                    Failure: NugetLookupFailure.VersionNotFound));
+            }
+        }
+
+        var libDir = Path.Combine(packageDir, resolvedVersion, "lib");
+        if (!Directory.Exists(libDir))
+        {
+            return Task.FromResult(new NugetAssemblyLookup(
+                packageId,
+                version,
+                tfm,
+                resolvedVersion,
+                ResolvedTfm: null,
+                cacheRoot,
+                FoundAssembly: null,
+                AvailableVersions: SortVersionsDescending(availableVersions),
+                AvailableTfms: Array.Empty<string>(),
+                Failure: NugetLookupFailure.AssemblyNotFound));
+        }
+
+        var availableTfms = Directory.GetDirectories(libDir)
+            .Select(Path.GetFileName)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .Cast<string>()
+            .ToArray();
+
+        var resolvedTfm = tfm is not null
+            ? PickCompatibleTfm(availableTfms, tfm)
+            : PickBestTfm(availableTfms);
+
+        if (resolvedTfm is null)
+        {
+            return Task.FromResult(new NugetAssemblyLookup(
+                packageId,
+                version,
+                tfm,
+                resolvedVersion,
+                ResolvedTfm: null,
+                cacheRoot,
+                FoundAssembly: null,
+                AvailableVersions: SortVersionsDescending(availableVersions),
+                AvailableTfms: availableTfms,
+                Failure: NugetLookupFailure.AssemblyNotFound));
+        }
+
+        var tfmDir = Path.Combine(libDir, resolvedTfm);
+        var dlls = Directory.GetFiles(tfmDir, "*.dll", SearchOption.TopDirectoryOnly);
+        var foundAssembly = PickAssemblyForPackage(dlls, packageId);
+
+        return Task.FromResult(new NugetAssemblyLookup(
+            packageId,
+            version,
+            tfm,
+            resolvedVersion,
+            resolvedTfm,
+            cacheRoot,
+            foundAssembly,
+            AvailableVersions: SortVersionsDescending(availableVersions),
+            AvailableTfms: availableTfms,
+            Failure: foundAssembly is null ? NugetLookupFailure.AssemblyNotFound : null));
+    }
+
+    private static string GetNugetCacheRoot()
+    {
+        var overridePath = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (!string.IsNullOrWhiteSpace(overridePath))
+            return overridePath;
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(userProfile, ".nuget", "packages");
+    }
+
+    private static string? PickHighestVersion(string[] versions)
+    {
+        if (versions.Length == 0)
+            return null;
+        var parsed = versions
+            .Select(v => (raw: v, parsed: TryParseVersion(v)))
+            .ToArray();
+        var withParsed = parsed.Where(p => p.parsed is not null).ToArray();
+        if (withParsed.Length > 0)
+            return withParsed.OrderByDescending(p => p.parsed!).First().raw;
+        return versions.OrderByDescending(v => v, StringComparer.OrdinalIgnoreCase).First();
+    }
+
+    private static Version? TryParseVersion(string raw)
+    {
+        var dash = raw.IndexOf('-');
+        var core = dash >= 0 ? raw[..dash] : raw;
+        return Version.TryParse(core, out var v) ? v : null;
+    }
+
+    private static string[] SortVersionsDescending(string[] versions)
+    {
+        return versions
+            .Select(v => (raw: v, parsed: TryParseVersion(v)))
+            .OrderByDescending(p => p.parsed ?? new Version(0, 0))
+            .ThenByDescending(p => p.raw, StringComparer.OrdinalIgnoreCase)
+            .Select(p => p.raw)
+            .ToArray();
+    }
+
+    private static string? PickBestTfm(string[] availableTfms)
+    {
+        if (availableTfms.Length == 0)
+            return null;
+        var ranked = availableTfms
+            .Select(t => (raw: t, rank: RankTfm(t)))
+            .OrderBy(t => t.rank.family)
+            .ThenByDescending(t => t.rank.version)
+            .ThenBy(t => t.raw, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return ranked[0].raw;
+    }
+
+    private static string? PickCompatibleTfm(string[] availableTfms, string requested)
+    {
+        var exact = availableTfms.FirstOrDefault(t => t.Equals(requested, StringComparison.OrdinalIgnoreCase));
+        if (exact is not null)
+            return exact;
+        var compatible = availableTfms
+            .Where(t => IsCompatibleFramework(t, requested))
+            .OrderByDescending(t => t, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+        return compatible;
+    }
+
+    private static (int family, Version version) RankTfm(string tfm)
+    {
+        var lower = tfm.ToLowerInvariant();
+        if (lower.StartsWith("net") && !lower.StartsWith("netstandard") && !lower.StartsWith("netcoreapp") && !lower.Contains("framework"))
+        {
+            var rest = lower[3..];
+            return (0, TryParseVersion(rest) ?? new Version(0, 0));
+        }
+        if (lower.StartsWith("netcoreapp"))
+            return (1, TryParseVersion(lower[10..]) ?? new Version(0, 0));
+        if (lower.StartsWith("netstandard"))
+            return (2, TryParseVersion(lower[11..]) ?? new Version(0, 0));
+        return (3, new Version(0, 0));
+    }
+
+    private static string? PickAssemblyForPackage(string[] dlls, string packageId)
+    {
+        if (dlls.Length == 0)
+            return null;
+        var preferredName = packageId + ".dll";
+        var preferred = dlls.FirstOrDefault(d =>
+            Path.GetFileName(d).Equals(preferredName, StringComparison.OrdinalIgnoreCase));
+        return preferred ?? dlls.OrderBy(d => d, StringComparer.OrdinalIgnoreCase).First();
+    }
+
     private static string? GetPropertyValue(IEnumerable<XElement> propertyGroups, string propertyName)
     {
         return propertyGroups
@@ -182,8 +393,7 @@ public class ProjectAnalysisService : IProjectAnalysisService
     private async Task<string[]> ResolvePackageAssemblyPathsAsync(PackageReference package, string[] targetFrameworks)
     {
         var assemblyPaths = new List<string>();
-        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var nugetCachePath = Path.Combine(userProfile, ".nuget", "packages");
+        var nugetCachePath = GetNugetCacheRoot();
         if (Directory.Exists(nugetCachePath))
         {
             var packagePath = Path.Combine(nugetCachePath, package.Name.ToLowerInvariant(), package.Version);

--- a/src/server/Sherlock.MCP.Server.csproj
+++ b/src/server/Sherlock.MCP.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.7.2</Version>
+    <Version>2.8.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/server/Tools/ReflectionTools.cs
+++ b/src/server/Tools/ReflectionTools.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Text.Json;
 using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Contracts.ProjectAnalysis;
 using Sherlock.MCP.Runtime.Inspection;
 using Sherlock.MCP.Server.Shared;
 
@@ -382,6 +383,67 @@ public static class ReflectionTools
         catch (Exception ex)
         {
             return JsonHelpers.Error("InternalError", $"Failed to search for assembly: {ex.Message}");
+        }
+    }
+
+    [McpServerTool]
+    [Description("Finds an assembly in the local NuGet cache by package id. Probes ~/.nuget/packages (or NUGET_PACKAGES env var). Use when you know the package id/version but not the DLL path. Picks highest version and best TFM when omitted.")]
+    public static async Task<string> FindAssemblyByNugetPackage(
+        IProjectAnalysisService projectAnalysis,
+        [Description("The NuGet package id (case-insensitive, e.g., 'Newtonsoft.Json').")] string packageId,
+        [Description("Optional package version (e.g., '13.0.3'). If omitted, the highest available version is picked.")] string? version = null,
+        [Description("Optional target framework moniker (e.g., 'net9.0'). If omitted, the best available TFM is picked.")] string? tfm = null)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(packageId))
+                return JsonHelpers.Error("InvalidArgument", "packageId must be provided.");
+
+            var lookup = await projectAnalysis.FindAssemblyInNugetCacheAsync(packageId, version, tfm);
+
+            if (lookup.Failure is NugetLookupFailure failure)
+            {
+                var code = failure switch
+                {
+                    NugetLookupFailure.PackageNotFound => "PackageNotFound",
+                    NugetLookupFailure.VersionNotFound => "VersionNotFound",
+                    _ => "AssemblyNotFound"
+                };
+                var message = failure switch
+                {
+                    NugetLookupFailure.PackageNotFound => $"Package '{packageId}' not found under NuGet cache '{lookup.CacheRoot}'.",
+                    NugetLookupFailure.VersionNotFound => version is null
+                        ? $"No versions available for package '{packageId}' under '{lookup.CacheRoot}'."
+                        : $"Version '{version}' not found for package '{packageId}'.",
+                    _ => $"No compatible assembly found for '{packageId}' {lookup.ResolvedVersion} (tfm: {tfm ?? "any"})."
+                };
+                return JsonHelpers.Error(code, message, new
+                {
+                    packageId,
+                    requestedVersion = version,
+                    requestedTfm = tfm,
+                    resolvedVersion = lookup.ResolvedVersion,
+                    cacheRoot = lookup.CacheRoot,
+                    availableVersions = lookup.AvailableVersions,
+                    availableTfms = lookup.AvailableTfms
+                });
+            }
+
+            var result = new
+            {
+                packageId = lookup.PackageId,
+                requestedVersion = lookup.RequestedVersion,
+                requestedTfm = lookup.RequestedTfm,
+                resolvedVersion = lookup.ResolvedVersion,
+                resolvedTfm = lookup.ResolvedTfm,
+                cacheRoot = lookup.CacheRoot,
+                foundAssembly = lookup.FoundAssembly
+            };
+            return JsonHelpers.Envelope("reflection.findByNugetPackage", result);
+        }
+        catch (Exception ex)
+        {
+            return JsonHelpers.Error("InternalError", $"Failed to resolve NuGet package: {ex.Message}");
         }
     }
 

--- a/src/server/Tools/ReflectionTools.cs
+++ b/src/server/Tools/ReflectionTools.cs
@@ -399,7 +399,15 @@ public static class ReflectionTools
             if (string.IsNullOrWhiteSpace(packageId))
                 return JsonHelpers.Error("InvalidArgument", "packageId must be provided.");
 
-            var lookup = await projectAnalysis.FindAssemblyInNugetCacheAsync(packageId, version, tfm);
+            NugetAssemblyLookup lookup;
+            try
+            {
+                lookup = await projectAnalysis.FindAssemblyInNugetCacheAsync(packageId, version, tfm);
+            }
+            catch (ArgumentException ex)
+            {
+                return JsonHelpers.Error("InvalidArgument", ex.Message);
+            }
 
             if (lookup.Failure is NugetLookupFailure failure)
             {

--- a/src/unit-tests/ProjectAnalysisServiceTests.cs
+++ b/src/unit-tests/ProjectAnalysisServiceTests.cs
@@ -3,6 +3,10 @@ using Sherlock.MCP.Runtime.Contracts.ProjectAnalysis;
 
 namespace Sherlock.MCP.Tests;
 
+[CollectionDefinition(nameof(EnvVarCollection), DisableParallelization = true)]
+public class EnvVarCollection { }
+
+[Collection(nameof(EnvVarCollection))]
 public class ProjectAnalysisServiceTests
 {
     private readonly IProjectAnalysisService _service = new ProjectAnalysisService();
@@ -231,6 +235,50 @@ public class ProjectAnalysisServiceTests
 
         Assert.Equal(NugetLookupFailure.AssemblyNotFound, result.Failure);
         Assert.Contains("net6.0", result.AvailableTfms);
+    }
+
+    [Fact]
+    public async Task FindAssemblyInNugetCache_Does_Not_Rank_Net48_Above_Net9()
+    {
+        using var cache = new TempDir();
+        SeedPackage(cache.Path, "Some.Pkg", "1.0.0", "net48");
+        SeedPackage(cache.Path, "Some.Pkg", "1.0.0", "net9.0");
+        using var _ = new EnvVar("NUGET_PACKAGES", cache.Path);
+
+        var result = await _service.FindAssemblyInNugetCacheAsync("Some.Pkg", "1.0.0");
+
+        Assert.Null(result.Failure);
+        Assert.Equal("net9.0", result.ResolvedTfm);
+    }
+
+    [Fact]
+    public async Task FindAssemblyInNugetCache_Prefers_Stable_Over_PreRelease()
+    {
+        using var cache = new TempDir();
+        SeedPackage(cache.Path, "Some.Pkg", "1.2.3", "net9.0");
+        SeedPackage(cache.Path, "Some.Pkg", "1.2.3-preview1", "net9.0");
+        SeedPackage(cache.Path, "Some.Pkg", "1.2.4-preview1", "net9.0");
+        using var _ = new EnvVar("NUGET_PACKAGES", cache.Path);
+
+        var result = await _service.FindAssemblyInNugetCacheAsync("Some.Pkg");
+
+        Assert.Null(result.Failure);
+        Assert.Equal("1.2.3", result.ResolvedVersion);
+    }
+
+    [Theory]
+    [InlineData("../../etc/passwd")]
+    [InlineData("Some/Pkg")]
+    [InlineData("Some\\Pkg")]
+    [InlineData("/absolute/path")]
+    [InlineData("Pkg!Name")]
+    public async Task FindAssemblyInNugetCache_Rejects_Invalid_PackageId(string packageId)
+    {
+        using var cache = new TempDir();
+        using var _ = new EnvVar("NUGET_PACKAGES", cache.Path);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            _service.FindAssemblyInNugetCacheAsync(packageId));
     }
 
     [Fact]

--- a/src/unit-tests/ProjectAnalysisServiceTests.cs
+++ b/src/unit-tests/ProjectAnalysisServiceTests.cs
@@ -133,6 +133,128 @@ public class ProjectAnalysisServiceTests
     }
 
     [Fact]
+    public async Task FindAssemblyInNugetCache_Returns_ExactMatch_When_Version_And_Tfm_Provided()
+    {
+        using var cache = new TempDir();
+        SeedPackage(cache.Path, "Sharp.Events", "41.0.1", "net9.0");
+        using var _ = new EnvVar("NUGET_PACKAGES", cache.Path);
+
+        var result = await _service.FindAssemblyInNugetCacheAsync("Sharp.Events", "41.0.1", "net9.0");
+
+        Assert.Null(result.Failure);
+        Assert.Equal("41.0.1", result.ResolvedVersion);
+        Assert.Equal("net9.0", result.ResolvedTfm);
+        Assert.NotNull(result.FoundAssembly);
+        Assert.EndsWith(Path.Combine("lib", "net9.0", "Sharp.Events.dll"), result.FoundAssembly);
+        Assert.True(File.Exists(result.FoundAssembly));
+    }
+
+    [Fact]
+    public async Task FindAssemblyInNugetCache_Picks_Highest_Version_When_Omitted()
+    {
+        using var cache = new TempDir();
+        SeedPackage(cache.Path, "Sharp.Events", "41.0.1", "net9.0");
+        SeedPackage(cache.Path, "Sharp.Events", "41.2.0", "net9.0");
+        SeedPackage(cache.Path, "Sharp.Events", "40.9.5", "net9.0");
+        using var _ = new EnvVar("NUGET_PACKAGES", cache.Path);
+
+        var result = await _service.FindAssemblyInNugetCacheAsync("Sharp.Events");
+
+        Assert.Null(result.Failure);
+        Assert.Equal("41.2.0", result.ResolvedVersion);
+        Assert.Contains("41.2.0", result.AvailableVersions);
+        Assert.Contains("41.0.1", result.AvailableVersions);
+        Assert.Contains("40.9.5", result.AvailableVersions);
+    }
+
+    [Fact]
+    public async Task FindAssemblyInNugetCache_Picks_Best_Tfm_When_Omitted()
+    {
+        using var cache = new TempDir();
+        SeedPackage(cache.Path, "Some.Pkg", "1.0.0", "netstandard2.0");
+        SeedPackage(cache.Path, "Some.Pkg", "1.0.0", "net8.0");
+        SeedPackage(cache.Path, "Some.Pkg", "1.0.0", "net9.0");
+        using var _ = new EnvVar("NUGET_PACKAGES", cache.Path);
+
+        var result = await _service.FindAssemblyInNugetCacheAsync("Some.Pkg", "1.0.0");
+
+        Assert.Null(result.Failure);
+        Assert.Equal("net9.0", result.ResolvedTfm);
+    }
+
+    [Fact]
+    public async Task FindAssemblyInNugetCache_Falls_Back_To_Compatible_Tfm()
+    {
+        using var cache = new TempDir();
+        SeedPackage(cache.Path, "Legacy.Pkg", "1.0.0", "netstandard2.0");
+        using var _ = new EnvVar("NUGET_PACKAGES", cache.Path);
+
+        var result = await _service.FindAssemblyInNugetCacheAsync("Legacy.Pkg", "1.0.0", "net9.0");
+
+        Assert.Null(result.Failure);
+        Assert.Equal("netstandard2.0", result.ResolvedTfm);
+    }
+
+    [Fact]
+    public async Task FindAssemblyInNugetCache_Reports_PackageNotFound()
+    {
+        using var cache = new TempDir();
+        using var _ = new EnvVar("NUGET_PACKAGES", cache.Path);
+
+        var result = await _service.FindAssemblyInNugetCacheAsync("Does.Not.Exist");
+
+        Assert.Equal(NugetLookupFailure.PackageNotFound, result.Failure);
+        Assert.Null(result.FoundAssembly);
+    }
+
+    [Fact]
+    public async Task FindAssemblyInNugetCache_Reports_VersionNotFound_With_Available()
+    {
+        using var cache = new TempDir();
+        SeedPackage(cache.Path, "Sharp.Events", "41.0.1", "net9.0");
+        using var _ = new EnvVar("NUGET_PACKAGES", cache.Path);
+
+        var result = await _service.FindAssemblyInNugetCacheAsync("Sharp.Events", "99.0.0");
+
+        Assert.Equal(NugetLookupFailure.VersionNotFound, result.Failure);
+        Assert.Contains("41.0.1", result.AvailableVersions);
+    }
+
+    [Fact]
+    public async Task FindAssemblyInNugetCache_Reports_AssemblyNotFound_When_Tfm_Missing()
+    {
+        using var cache = new TempDir();
+        SeedPackage(cache.Path, "Sharp.Events", "41.0.1", "net6.0");
+        using var _ = new EnvVar("NUGET_PACKAGES", cache.Path);
+
+        var result = await _service.FindAssemblyInNugetCacheAsync("Sharp.Events", "41.0.1", "net481");
+
+        Assert.Equal(NugetLookupFailure.AssemblyNotFound, result.Failure);
+        Assert.Contains("net6.0", result.AvailableTfms);
+    }
+
+    [Fact]
+    public async Task FindAssemblyInNugetCache_Honors_NUGET_PACKAGES_Env_Var()
+    {
+        using var cache = new TempDir();
+        SeedPackage(cache.Path, "EnvVar.Pkg", "2.0.0", "net9.0");
+        using var _ = new EnvVar("NUGET_PACKAGES", cache.Path);
+
+        var result = await _service.FindAssemblyInNugetCacheAsync("EnvVar.Pkg");
+
+        Assert.Null(result.Failure);
+        Assert.Equal(cache.Path, result.CacheRoot);
+        Assert.StartsWith(cache.Path, result.FoundAssembly!);
+    }
+
+    private static void SeedPackage(string cacheRoot, string packageId, string version, string tfm)
+    {
+        var tfmDir = Path.Combine(cacheRoot, packageId.ToLowerInvariant(), version, "lib", tfm);
+        Directory.CreateDirectory(tfmDir);
+        File.WriteAllBytes(Path.Combine(tfmDir, packageId + ".dll"), new byte[] { 0x4D, 0x5A });
+    }
+
+    [Fact]
     public async Task FindDepsJson_Parses_Libraries_When_File_Exists()
     {
         using var temp = new TempDir();
@@ -173,4 +295,17 @@ internal sealed class TempDir : IDisposable
     {
         try { Directory.Delete(Path, true); } catch { }
     }
+}
+
+internal sealed class EnvVar : IDisposable
+{
+    private readonly string _name;
+    private readonly string? _previous;
+    public EnvVar(string name, string? value)
+    {
+        _name = name;
+        _previous = Environment.GetEnvironmentVariable(name);
+        Environment.SetEnvironmentVariable(name, value);
+    }
+    public void Dispose() => Environment.SetEnvironmentVariable(_name, _previous);
 }


### PR DESCRIPTION
Closes #23.

## Summary
- New `FindAssemblyByNugetPackage(packageId, version?, tfm?)` MCP tool that resolves a DLL from the local NuGet cache directly — no `.csproj` required. Saves the caller from manually grepping `~/.nuget/packages`.
- Cache-root resolution now honors the `NUGET_PACKAGES` env var (drive-by fix that also benefits the existing `ResolvePackageReferences` tool, which previously only consulted `~/.nuget/packages`).
- Selection rules when params are omitted:
  - **Version**: highest parseable `System.Version`, falls back to descending `OrdinalIgnoreCase` for pre-release / non-numeric.
  - **TFM**: `net*` > `netcoreapp*` > `netstandard*`, highest numeric within each family.
  - **TFM given but not an exact folder**: reuses the existing `IsCompatibleFramework` fallback so requesting `net9.0` still picks `netstandard2.1` when that's all that ships.
- Returns structured errors (`PackageNotFound` / `VersionNotFound` / `AssemblyNotFound`) with `availableVersions` / `availableTfms` in the error details so the caller can course-correct without a second probe.
- Shorthand `pkgid:version` on every `assemblyPath` parameter is explicitly deferred (per the issue); can be a follow-up.

## Test plan
- [x] `dotnet build src/Sherlock.MCP.sln` — clean, 0 warnings
- [x] `dotnet test src/Sherlock.MCP.sln --framework net10.0` — all 106 tests pass (5 existing + 8 new cases covering exact match, omitted version, omitted TFM, compatible-TFM fallback, `PackageNotFound`, `VersionNotFound`, `AssemblyNotFound` when TFM missing, `NUGET_PACKAGES` env-var override)
- [ ] Manual MCP smoke: call `FindAssemblyByNugetPackage(packageId: "Newtonsoft.Json")` against a populated cache; expect `foundAssembly` ending in `lib/<tfm>/Newtonsoft.Json.dll`.
- [ ] Manual MCP smoke: call with `packageId: "Does.Not.Exist"`; expect `PackageNotFound`.
- [ ] Manual MCP smoke: `NUGET_PACKAGES=/tmp/empty` → expect `PackageNotFound` (confirms env-var override takes effect end-to-end).