### PR TITLE
fix(runtime): polish signature rendering for consumer output

### DIFF
--- a/src/runtime/MemberAnalysisService.cs
+++ b/src/runtime/MemberAnalysisService.cs
@@ -286,7 +286,7 @@ public class MemberAnalysisService : IMemberAnalysisService, IDisposable
         return parameters.Select(p => new ParameterDetails(
             Name: p.Name ?? "param",
             TypeName: GetFriendlyTypeName(p.ParameterType),
-            DefaultValue: p.HasDefaultValue ? SafeGetRawDefaultValue(p)?.ToString() : null,
+            DefaultValue: p.HasDefaultValue ? FormatDefaultLiteral(SafeGetRawDefaultValue(p)) : null,
             IsOptional: p.IsOptional,
             IsOut: p.IsOut,
             IsRef: p.ParameterType.IsByRef && !p.IsOut,
@@ -302,6 +302,17 @@ public class MemberAnalysisService : IMemberAnalysisService, IDisposable
         try { return p.RawDefaultValue; }
         catch { return null; }
     }
+
+    private static string FormatDefaultLiteral(object? value) => value switch
+    {
+        null => "null",
+        bool b => b ? "true" : "false",
+        string s => $"\"{s}\"",
+        char c => $"'{c}'",
+        Enum e => $"{e.GetType().Name}.{e}",
+        IFormattable f => f.ToString(null, System.Globalization.CultureInfo.InvariantCulture),
+        _ => value.ToString() ?? "null"
+    };
 
     private static IEnumerable<T> ApplyMemberFilters<T>(IEnumerable<T> source, MemberFilterOptions? options, Func<T, string> nameSelector, Func<T, Sherlock.MCP.Runtime.Contracts.TypeAnalysis.AttributeInfo[]> attrSelector)
     {
@@ -347,6 +358,10 @@ public class MemberAnalysisService : IMemberAnalysisService, IDisposable
             var rank = type.GetArrayRank();
             var brackets = rank == 1 ? "[]" : "[" + new string(',', rank - 1) + "]";
             return elementType + brackets;
+        }
+        if (type.IsGenericType && !type.IsGenericTypeDefinition && type.GetGenericTypeDefinition().FullName == "System.Nullable`1")
+        {
+            return GetFriendlyTypeName(type.GetGenericArguments()[0]) + "?";
         }
         if (type.IsGenericType)
         {
@@ -425,14 +440,20 @@ public class MemberAnalysisService : IMemberAnalysisService, IDisposable
         var requiredModifiers = field.GetRequiredCustomModifiers();
         return requiredModifiers.Any(m => m.FullName == "System.Runtime.CompilerServices.IsVolatile");
     }
+    private static bool IsInterfaceMember(MemberInfo member) => member.DeclaringType?.IsInterface == true;
+
     private static string BuildMethodSignature(MethodInfo method, ParameterDetails[] parameters, string[] genericParams)
     {
         var sb = new StringBuilder();
-        sb.Append(GetAccessModifier(method));
-        sb.Append(' ');
+        var onInterface = IsInterfaceMember(method);
+        if (!onInterface)
+        {
+            sb.Append(GetAccessModifier(method));
+            sb.Append(' ');
+        }
         if (method.IsStatic) sb.Append("static ");
-        if (method.IsAbstract) sb.Append("abstract ");
-        else if (method.IsVirtual && !method.IsFinal && !IsOverrideMethod(method)) sb.Append("virtual ");
+        if (method.IsAbstract && !onInterface) sb.Append("abstract ");
+        else if (method.IsVirtual && !method.IsFinal && !IsOverrideMethod(method) && !onInterface) sb.Append("virtual ");
         else if (IsOverrideMethod(method)) sb.Append("override ");
         else if (method.IsFinal && method.IsVirtual) sb.Append("sealed ");
         sb.Append(GetFriendlyTypeName(method.ReturnType));
@@ -453,16 +474,20 @@ public class MemberAnalysisService : IMemberAnalysisService, IDisposable
     private static string BuildPropertySignature(PropertyInfo property, ParameterDetails[] indexerParams)
     {
         var sb = new StringBuilder();
+        var onInterface = IsInterfaceMember(property);
         var getMethod = property.GetGetMethod(true);
         var setMethod = property.GetSetMethod(true);
         var primaryMethod = getMethod ?? setMethod;
         if (primaryMethod != null)
         {
-            sb.Append(GetAccessModifier(primaryMethod));
-            sb.Append(' ');
+            if (!onInterface)
+            {
+                sb.Append(GetAccessModifier(primaryMethod));
+                sb.Append(' ');
+            }
             if (primaryMethod.IsStatic) sb.Append("static ");
-            if (primaryMethod.IsAbstract) sb.Append("abstract ");
-            else if (primaryMethod.IsVirtual && !primaryMethod.IsFinal && !IsOverrideMethod(primaryMethod)) sb.Append("virtual ");
+            if (primaryMethod.IsAbstract && !onInterface) sb.Append("abstract ");
+            else if (primaryMethod.IsVirtual && !primaryMethod.IsFinal && !IsOverrideMethod(primaryMethod) && !onInterface) sb.Append("virtual ");
             else if (IsOverrideMethod(primaryMethod)) sb.Append("override ");
             else if (primaryMethod.IsFinal && primaryMethod.IsVirtual) sb.Append("sealed ");
         }
@@ -502,15 +527,19 @@ public class MemberAnalysisService : IMemberAnalysisService, IDisposable
     private static string BuildEventSignature(EventInfo eventInfo)
     {
         var sb = new StringBuilder();
+        var onInterface = IsInterfaceMember(eventInfo);
         var addMethod = eventInfo.GetAddMethod(true);
         var primaryMethod = addMethod;
         if (primaryMethod != null)
         {
-            sb.Append(GetAccessModifier(primaryMethod));
-            sb.Append(' ');
+            if (!onInterface)
+            {
+                sb.Append(GetAccessModifier(primaryMethod));
+                sb.Append(' ');
+            }
             if (primaryMethod.IsStatic) sb.Append("static ");
-            if (primaryMethod.IsAbstract) sb.Append("abstract ");
-            else if (primaryMethod.IsVirtual && !primaryMethod.IsFinal && !IsOverrideMethod(primaryMethod)) sb.Append("virtual ");
+            if (primaryMethod.IsAbstract && !onInterface) sb.Append("abstract ");
+            else if (primaryMethod.IsVirtual && !primaryMethod.IsFinal && !IsOverrideMethod(primaryMethod) && !onInterface) sb.Append("virtual ");
             else if (IsOverrideMethod(primaryMethod)) sb.Append("override ");
             else if (primaryMethod.IsFinal && primaryMethod.IsVirtual) sb.Append("sealed ");
         }

--- a/src/runtime/MemberAnalysisService.cs
+++ b/src/runtime/MemberAnalysisService.cs
@@ -307,11 +307,36 @@ public class MemberAnalysisService : IMemberAnalysisService, IDisposable
     {
         null => "null",
         bool b => b ? "true" : "false",
-        string s => $"\"{s}\"",
-        char c => $"'{c}'",
+        string s => $"\"{EscapeCSharpString(s)}\"",
+        char c => $"'{EscapeCSharpChar(c)}'",
         Enum e => $"{e.GetType().Name}.{e}",
         IFormattable f => f.ToString(null, System.Globalization.CultureInfo.InvariantCulture),
         _ => value.ToString() ?? "null"
+    };
+
+    private static string EscapeCSharpString(string value)
+    {
+        var sb = new StringBuilder(value.Length);
+        foreach (var c in value) sb.Append(EscapeCSharpChar(c, isCharLiteral: false));
+        return sb.ToString();
+    }
+
+    private static string EscapeCSharpChar(char c) => EscapeCSharpChar(c, isCharLiteral: true);
+
+    private static string EscapeCSharpChar(char c, bool isCharLiteral) => c switch
+    {
+        '\\' => "\\\\",
+        '\0' => "\\0",
+        '\a' => "\\a",
+        '\b' => "\\b",
+        '\f' => "\\f",
+        '\n' => "\\n",
+        '\r' => "\\r",
+        '\t' => "\\t",
+        '\v' => "\\v",
+        '"' when !isCharLiteral => "\\\"",
+        '\'' when isCharLiteral => "\\'",
+        _ => c.ToString()
     };
 
     private static IEnumerable<T> ApplyMemberFilters<T>(IEnumerable<T> source, MemberFilterOptions? options, Func<T, string> nameSelector, Func<T, Sherlock.MCP.Runtime.Contracts.TypeAnalysis.AttributeInfo[]> attrSelector)
@@ -446,14 +471,16 @@ public class MemberAnalysisService : IMemberAnalysisService, IDisposable
     {
         var sb = new StringBuilder();
         var onInterface = IsInterfaceMember(method);
-        if (!onInterface)
+        var suppressPublic = onInterface && method.IsPublic;
+        var suppressImplicitAbstractVirtual = onInterface && !method.IsStatic;
+        if (!suppressPublic)
         {
             sb.Append(GetAccessModifier(method));
             sb.Append(' ');
         }
         if (method.IsStatic) sb.Append("static ");
-        if (method.IsAbstract && !onInterface) sb.Append("abstract ");
-        else if (method.IsVirtual && !method.IsFinal && !IsOverrideMethod(method) && !onInterface) sb.Append("virtual ");
+        if (method.IsAbstract && !suppressImplicitAbstractVirtual) sb.Append("abstract ");
+        else if (method.IsVirtual && !method.IsFinal && !IsOverrideMethod(method) && !suppressImplicitAbstractVirtual) sb.Append("virtual ");
         else if (IsOverrideMethod(method)) sb.Append("override ");
         else if (method.IsFinal && method.IsVirtual) sb.Append("sealed ");
         sb.Append(GetFriendlyTypeName(method.ReturnType));
@@ -480,14 +507,16 @@ public class MemberAnalysisService : IMemberAnalysisService, IDisposable
         var primaryMethod = getMethod ?? setMethod;
         if (primaryMethod != null)
         {
-            if (!onInterface)
+            var suppressPublic = onInterface && primaryMethod.IsPublic;
+            var suppressImplicitAbstractVirtual = onInterface && !primaryMethod.IsStatic;
+            if (!suppressPublic)
             {
                 sb.Append(GetAccessModifier(primaryMethod));
                 sb.Append(' ');
             }
             if (primaryMethod.IsStatic) sb.Append("static ");
-            if (primaryMethod.IsAbstract && !onInterface) sb.Append("abstract ");
-            else if (primaryMethod.IsVirtual && !primaryMethod.IsFinal && !IsOverrideMethod(primaryMethod) && !onInterface) sb.Append("virtual ");
+            if (primaryMethod.IsAbstract && !suppressImplicitAbstractVirtual) sb.Append("abstract ");
+            else if (primaryMethod.IsVirtual && !primaryMethod.IsFinal && !IsOverrideMethod(primaryMethod) && !suppressImplicitAbstractVirtual) sb.Append("virtual ");
             else if (IsOverrideMethod(primaryMethod)) sb.Append("override ");
             else if (primaryMethod.IsFinal && primaryMethod.IsVirtual) sb.Append("sealed ");
         }
@@ -532,14 +561,16 @@ public class MemberAnalysisService : IMemberAnalysisService, IDisposable
         var primaryMethod = addMethod;
         if (primaryMethod != null)
         {
-            if (!onInterface)
+            var suppressPublic = onInterface && primaryMethod.IsPublic;
+            var suppressImplicitAbstractVirtual = onInterface && !primaryMethod.IsStatic;
+            if (!suppressPublic)
             {
                 sb.Append(GetAccessModifier(primaryMethod));
                 sb.Append(' ');
             }
             if (primaryMethod.IsStatic) sb.Append("static ");
-            if (primaryMethod.IsAbstract && !onInterface) sb.Append("abstract ");
-            else if (primaryMethod.IsVirtual && !primaryMethod.IsFinal && !IsOverrideMethod(primaryMethod) && !onInterface) sb.Append("virtual ");
+            if (primaryMethod.IsAbstract && !suppressImplicitAbstractVirtual) sb.Append("abstract ");
+            else if (primaryMethod.IsVirtual && !primaryMethod.IsFinal && !IsOverrideMethod(primaryMethod) && !suppressImplicitAbstractVirtual) sb.Append("virtual ");
             else if (IsOverrideMethod(primaryMethod)) sb.Append("override ");
             else if (primaryMethod.IsFinal && primaryMethod.IsVirtual) sb.Append("sealed ");
         }

--- a/src/runtime/ReverseLookupService.cs
+++ b/src/runtime/ReverseLookupService.cs
@@ -19,13 +19,13 @@ public class ReverseLookupService : IReverseLookupService
                 {
                     var matchedInterfaces = GetInterfacesSafe(candidate)
                         .Where(i => TypeNameMatcher.Matches(i, typeName, options.CaseSensitive))
-                        .Select(i => i.FullName ?? i.Name)
+                        .Select(TypeNameFormatter.FriendlyFullName)
                         .ToArray();
 
                     var baseTypeChain = GetBaseTypeChain(candidate);
                     var matchedBases = baseTypeChain
                         .Where(b => TypeNameMatcher.Matches(b, typeName, options.CaseSensitive))
-                        .Select(b => b.FullName ?? b.Name)
+                        .Select(TypeNameFormatter.FriendlyFullName)
                         .ToArray();
 
                     if (matchedInterfaces.Length == 0 && matchedBases.Length == 0) continue;
@@ -33,10 +33,10 @@ public class ReverseLookupService : IReverseLookupService
                     var kind = matchedInterfaces.Length > 0 ? "interface" : "baseType";
                     hits.Add(new ImplementationHit(
                         AssemblyPath: path,
-                        TypeFullName: candidate.FullName ?? candidate.Name,
+                        TypeFullName: TypeNameFormatter.FriendlyFullName(candidate),
                         Kind: kind,
                         MatchedInterfaces: matchedInterfaces,
-                        BaseTypeChain: baseTypeChain.Select(b => b.FullName ?? b.Name).ToArray()));
+                        BaseTypeChain: baseTypeChain.Select(TypeNameFormatter.FriendlyFullName).ToArray()));
                 }
             })) continue;
         }
@@ -69,7 +69,7 @@ public class ReverseLookupService : IReverseLookupService
 
                         hits.Add(new MethodReturnHit(
                             AssemblyPath: path,
-                            DeclaringTypeFullName: candidate.FullName ?? candidate.Name,
+                            DeclaringTypeFullName: TypeNameFormatter.FriendlyFullName(candidate),
                             MethodName: method.Name,
                             Signature: FormatMethodSignature(method),
                             ReturnTypeFriendlyName: FriendlyTypeName(returnType),
@@ -113,7 +113,7 @@ public class ReverseLookupService : IReverseLookupService
             {
                 if (hits.Count >= cap) { truncated = true; break; }
 
-                var declaringName = candidate.FullName ?? candidate.Name;
+                var declaringName = TypeNameFormatter.FriendlyFullName(candidate);
 
                 Type? baseType = null;
                 try { baseType = candidate.BaseType; } catch { }
@@ -121,7 +121,7 @@ public class ReverseLookupService : IReverseLookupService
                 {
                     hits.Add(MakeRefHit(path, declaringName, "type", declaringName, "baseType",
                         $"{declaringName} : {FriendlyTypeName(baseType)}",
-                        disambiguator: baseType.FullName ?? baseType.Name));
+                        disambiguator: TypeNameFormatter.FriendlyFullName(baseType)));
                 }
 
                 foreach (var iface in GetInterfacesSafe(candidate))
@@ -130,7 +130,7 @@ public class ReverseLookupService : IReverseLookupService
                     if (!TypeNameMatcher.Matches(iface, typeName, options.CaseSensitive)) continue;
                     hits.Add(MakeRefHit(path, declaringName, "type", declaringName, "interface",
                         $"{declaringName} : {FriendlyTypeName(iface)}",
-                        disambiguator: iface.FullName ?? iface.Name));
+                        disambiguator: TypeNameFormatter.FriendlyFullName(iface)));
                 }
 
                 if (truncated) break;
@@ -145,7 +145,7 @@ public class ReverseLookupService : IReverseLookupService
                         if (!TypeNameMatcher.Matches(arg, typeName, options.CaseSensitive)) continue;
                         hits.Add(MakeRefHit(path, declaringName, "type", declaringName, "genericArg",
                             $"{declaringName}<{FriendlyTypeName(arg)}>",
-                            disambiguator: arg.FullName ?? arg.Name));
+                            disambiguator: TypeNameFormatter.FriendlyFullName(arg)));
                     }
                     if (truncated) break;
                 }
@@ -161,7 +161,7 @@ public class ReverseLookupService : IReverseLookupService
                     if (returnMatch != null)
                     {
                         hits.Add(MakeRefHit(path, declaringName, "method", method.Name, "return", sig,
-                            disambiguator: returnMatch.FullName ?? returnMatch.Name));
+                            disambiguator: TypeNameFormatter.FriendlyFullName(returnMatch)));
                     }
 
                     ParameterInfo[] parameters;
@@ -188,7 +188,7 @@ public class ReverseLookupService : IReverseLookupService
                     if (propMatch == null) continue;
                     hits.Add(MakeRefHit(path, declaringName, "property", prop.Name, "property",
                         $"{FriendlyTypeName(pt)} {prop.Name}",
-                        disambiguator: propMatch.FullName ?? propMatch.Name));
+                        disambiguator: TypeNameFormatter.FriendlyFullName(propMatch)));
                 }
 
                 if (truncated) break;
@@ -202,7 +202,7 @@ public class ReverseLookupService : IReverseLookupService
                     if (fieldMatch == null) continue;
                     hits.Add(MakeRefHit(path, declaringName, "field", field.Name, "field",
                         $"{FriendlyTypeName(ft)} {field.Name}",
-                        disambiguator: fieldMatch.FullName ?? fieldMatch.Name));
+                        disambiguator: TypeNameFormatter.FriendlyFullName(fieldMatch)));
                 }
 
                 if (truncated) break;
@@ -216,7 +216,7 @@ public class ReverseLookupService : IReverseLookupService
                     if (eventMatch == null) continue;
                     hits.Add(MakeRefHit(path, declaringName, "event", evt.Name, "event",
                         $"event {FriendlyTypeName(et!)} {evt.Name}",
-                        disambiguator: eventMatch.FullName ?? eventMatch.Name));
+                        disambiguator: TypeNameFormatter.FriendlyFullName(eventMatch)));
                 }
             }
             }

--- a/src/runtime/TypeAnalysisService.cs
+++ b/src/runtime/TypeAnalysisService.cs
@@ -56,7 +56,7 @@ public class TypeAnalysisService : ITypeAnalysisService, IDisposable
     public TypeAnalysisInfo GetTypeInfo(Type type)
     {
         return new TypeAnalysisInfo(
-            FullName: type.FullName ?? type.Name,
+            FullName: TypeNameFormatter.FriendlyFullName(type),
             Name: type.Name,
             Namespace: type.Namespace,
             Kind: GetTypeKind(type),
@@ -67,8 +67,8 @@ public class TypeAnalysisService : ITypeAnalysisService, IDisposable
             IsGeneric: type.IsGenericType,
             IsNested: type.IsNested,
             AssemblyName: type.Assembly.GetName().Name,
-            BaseType: type.BaseType?.FullName,
-            Interfaces: [.. type.GetInterfaces().Select(i => i.FullName ?? i.Name)],
+            BaseType: type.BaseType is null ? null : TypeNameFormatter.FriendlyFullName(type.BaseType),
+            Interfaces: [.. type.GetInterfaces().Select(TypeNameFormatter.FriendlyFullName)],
             Attributes: GetTypeAttributes(type),
             GenericParameters: type.IsGenericType ? GetGenericParameters(type) : [],
             NestedTypes: GetNestedTypes(type)
@@ -97,20 +97,20 @@ public class TypeAnalysisService : ITypeAnalysisService, IDisposable
 
         while (current != null)
         {
-            inheritanceChain.Add(current.FullName ?? current.Name);
+            inheritanceChain.Add(TypeNameFormatter.FriendlyFullName(current));
             baseTypes.Add(GetTypeInfo(current));
             current = current.BaseType;
         }
 
         var allInterfaces = type.GetInterfaces()
-            .Select(i => i.FullName ?? i.Name)
+            .Select(TypeNameFormatter.FriendlyFullName)
             .ToArray();
 
         // Note: Getting derived types requires scanning all loaded assemblies
         // This is expensive and might not be practical in all scenarios
         var derivedTypes = Array.Empty<TypeAnalysisInfo>();
         return new TypeAnalysisHierarchy(
-            TypeName: type.FullName ?? type.Name,
+            TypeName: TypeNameFormatter.FriendlyFullName(type),
             InheritanceChain: inheritanceChain.ToArray(),
             AllInterfaces: allInterfaces,
             BaseTypes: baseTypes.ToArray(),
@@ -123,7 +123,7 @@ public class TypeAnalysisService : ITypeAnalysisService, IDisposable
         if (!type.IsGenericType)
         {
             return new TypeAnalysisGenericTypeInfo(
-                TypeName: type.FullName ?? type.Name,
+                TypeName: TypeNameFormatter.FriendlyFullName(type),
                 IsGenericTypeDefinition: false,
                 IsConstructedGenericType: false,
                 GenericParameters: [],
@@ -135,14 +135,14 @@ public class TypeAnalysisService : ITypeAnalysisService, IDisposable
         var genericParameters = GetGenericParameters(type);
         var genericArguments = type.IsGenericTypeDefinition
             ? []
-            : type.GetGenericArguments().Select(t => t.FullName ?? t.Name).ToArray();
+            : type.GetGenericArguments().Select(TypeNameFormatter.FriendlyFullName).ToArray();
 
         var variances = type.IsGenericTypeDefinition
             ? type.GetGenericArguments().Select(GetGenericVariance).ToArray()
             : [];
 
         return new TypeAnalysisGenericTypeInfo(
-            TypeName: type.FullName ?? type.Name,
+            TypeName: TypeNameFormatter.FriendlyFullName(type),
             IsGenericTypeDefinition: type.IsGenericTypeDefinition,
             IsConstructedGenericType: type.IsConstructedGenericType,
             GenericParameters: genericParameters,
@@ -250,7 +250,7 @@ public class TypeAnalysisService : ITypeAnalysisService, IDisposable
     private TypeAnalysisGenericParameterInfo CreateGenericParameterInfo(Type genericParameter)
     {
         var constraints = genericParameter.GetGenericParameterConstraints()
-            .Select(t => t.FullName ?? t.Name)
+            .Select(TypeNameFormatter.FriendlyFullName)
             .ToArray();
 
         var attrs = genericParameter.GenericParameterAttributes;

--- a/src/runtime/TypeNameFormatter.cs
+++ b/src/runtime/TypeNameFormatter.cs
@@ -1,0 +1,25 @@
+namespace Sherlock.MCP.Runtime;
+
+internal static class TypeNameFormatter
+{
+    public static string FriendlyFullName(System.Type type)
+    {
+        if (type.IsByRef) return FriendlyFullName(type.GetElementType()!) + "&";
+        if (type.IsPointer) return FriendlyFullName(type.GetElementType()!) + "*";
+        if (type.IsArray)
+        {
+            var rank = type.GetArrayRank();
+            var brackets = rank == 1 ? "[]" : "[" + new string(',', rank - 1) + "]";
+            return FriendlyFullName(type.GetElementType()!) + brackets;
+        }
+        if (type.IsGenericParameter) return type.Name;
+        if (!type.IsGenericType) return type.FullName ?? type.Name;
+
+        var def = type.GetGenericTypeDefinition();
+        var raw = def.FullName ?? def.Name;
+        var tick = raw.IndexOf('`');
+        var stem = tick > 0 ? raw.Substring(0, tick) : raw;
+        var args = type.GetGenericArguments().Select(FriendlyFullName);
+        return $"{stem}<{string.Join(", ", args)}>";
+    }
+}

--- a/src/server/Sherlock.MCP.Server.csproj
+++ b/src/server/Sherlock.MCP.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.8.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/server/Sherlock.MCP.Server.csproj
+++ b/src/server/Sherlock.MCP.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.8.1</Version>
+    <Version>2.8.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/unit-tests/SignatureRenderingTests.cs
+++ b/src/unit-tests/SignatureRenderingTests.cs
@@ -62,6 +62,29 @@ public class SignatureRenderingTests
     }
 
     [Fact]
+    public void StaticAbstractInterfaceMember_KeepsStaticAbstract()
+    {
+        var methods = _memberService.GetMethods(_testAssemblyPath,
+            "Sherlock.MCP.Tests.ITestSignatureShape");
+        var create = methods.FirstOrDefault(m => m.Name == "StaticCreate");
+        Assert.NotNull(create);
+        Assert.Contains("static", create.Signature);
+        Assert.Contains("abstract", create.Signature);
+        Assert.DoesNotContain("public", create.Signature);
+    }
+
+    [Fact]
+    public void StringAndCharDefaults_AreEscaped()
+    {
+        var methods = _memberService.GetMethods(_testAssemblyPath,
+            "Sherlock.MCP.Tests.NullableAndDefaults");
+        var quoted = methods.FirstOrDefault(m => m.Name == "QuotedDefaults");
+        Assert.NotNull(quoted);
+        Assert.Equal("\"a\\\"b\\\\c\"", quoted.Parameters[0].DefaultValue);
+        Assert.Equal("'\\''", quoted.Parameters[1].DefaultValue);
+    }
+
+    [Fact]
     public void GenericTypeFullName_HasNoBacktick()
     {
         var info = _typeService.GetTypeInfo(typeof(GenericHolder<,>));

--- a/src/unit-tests/SignatureRenderingTests.cs
+++ b/src/unit-tests/SignatureRenderingTests.cs
@@ -1,0 +1,75 @@
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Contracts.MemberAnalysis;
+using System.Reflection;
+
+namespace Sherlock.MCP.Tests;
+
+public class SignatureRenderingTests
+{
+    private readonly IMemberAnalysisService _memberService = new MemberAnalysisService();
+    private readonly ITypeAnalysisService _typeService = new TypeAnalysisService();
+    private readonly string _testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+    [Fact]
+    public void Nullable_RendersAsQuestionSuffix()
+    {
+        var methods = _memberService.GetMethods(_testAssemblyPath,
+            "Sherlock.MCP.Tests.NullableAndDefaults");
+        var nullables = methods.FirstOrDefault(m => m.Name == "Nullables");
+        Assert.NotNull(nullables);
+        Assert.Equal(2, nullables.Parameters.Length);
+        Assert.Equal("int?", nullables.Parameters[0].TypeName);
+        Assert.Equal("double?", nullables.Parameters[1].TypeName);
+        Assert.DoesNotContain("Nullable<", nullables.Signature);
+    }
+
+    [Fact]
+    public void Defaults_UseLowercaseCSharpLiterals()
+    {
+        var methods = _memberService.GetMethods(_testAssemblyPath,
+            "Sherlock.MCP.Tests.NullableAndDefaults");
+        var defaults = methods.FirstOrDefault(m => m.Name == "Defaults");
+        Assert.NotNull(defaults);
+        Assert.Equal("false", defaults.Parameters[0].DefaultValue);
+        Assert.Equal("null", defaults.Parameters[1].DefaultValue);
+        Assert.Equal("0", defaults.Parameters[2].DefaultValue);
+        Assert.Contains("flag = false", defaults.Signature);
+        Assert.Contains("name = null", defaults.Signature);
+    }
+
+    [Fact]
+    public void InterfaceMembers_OmitPublicAndAbstract()
+    {
+        var methods = _memberService.GetMethods(_testAssemblyPath,
+            "Sherlock.MCP.Tests.ITestSignatureShape");
+        var op = methods.FirstOrDefault(m => m.Name == "AbstractOp");
+        Assert.NotNull(op);
+        Assert.Equal("void AbstractOp(int id)", op.Signature);
+
+        var props = _memberService.GetProperties(_testAssemblyPath,
+            "Sherlock.MCP.Tests.ITestSignatureShape");
+        var label = props.FirstOrDefault(p => p.Name == "Label");
+        Assert.NotNull(label);
+        Assert.DoesNotContain("public", label.Signature);
+        Assert.DoesNotContain("abstract", label.Signature);
+
+        var events = _memberService.GetEvents(_testAssemblyPath,
+            "Sherlock.MCP.Tests.ITestSignatureShape");
+        var fired = events.FirstOrDefault(e => e.Name == "Fired");
+        Assert.NotNull(fired);
+        Assert.DoesNotContain("public", fired.Signature);
+        Assert.DoesNotContain("abstract", fired.Signature);
+    }
+
+    [Fact]
+    public void GenericTypeFullName_HasNoBacktick()
+    {
+        var info = _typeService.GetTypeInfo(typeof(GenericHolder<,>));
+        Assert.DoesNotContain("`", info.FullName);
+        Assert.Equal("Sherlock.MCP.Tests.GenericHolder<T, U>", info.FullName);
+
+        var closed = _typeService.GetTypeInfo(typeof(GenericHolder<int, string>));
+        Assert.DoesNotContain("`", closed.FullName);
+        Assert.Equal("Sherlock.MCP.Tests.GenericHolder<System.Int32, System.String>", closed.FullName);
+    }
+}

--- a/src/unit-tests/TestSampleClass.cs
+++ b/src/unit-tests/TestSampleClass.cs
@@ -46,12 +46,14 @@ public interface ITestSignatureShape
     void AbstractOp(int id);
     string Label { get; }
     event Action Fired;
+    static abstract int StaticCreate();
 }
 
 public class NullableAndDefaults
 {
     public void Nullables(int? maybeInt, System.Nullable<double> maybeDouble) { }
     public void Defaults(bool flag = false, string? name = null, int count = 0) { }
+    public void QuotedDefaults(string quote = "a\"b\\c", char tick = '\'') { }
 }
 
 public class GenericHolder<T, U>

--- a/src/unit-tests/TestSampleClass.cs
+++ b/src/unit-tests/TestSampleClass.cs
@@ -41,3 +41,21 @@ public class TestSampleClass
     public void OnPublicEvent() => PublicEvent?.Invoke();
 }
 
+public interface ITestSignatureShape
+{
+    void AbstractOp(int id);
+    string Label { get; }
+    event Action Fired;
+}
+
+public class NullableAndDefaults
+{
+    public void Nullables(int? maybeInt, System.Nullable<double> maybeDouble) { }
+    public void Defaults(bool flag = false, string? name = null, int count = 0) { }
+}
+
+public class GenericHolder<T, U>
+{
+    public T? Value { get; set; }
+}
+


### PR DESCRIPTION
## Summary

Closes #24.

Four cosmetic fixes to the JSON emitted by the type/member analysis tools:

- **`Nullable<T>` → `T?`** in the friendly type-name renderer (`MemberAnalysisService.GetFriendlyTypeName`).
- **C# default-value casing** — new `FormatDefaultLiteral` helper renders `true`/`false`/`null`/quoted-string/char/enum/invariant-formatted numbers instead of `.ToString()` output.
- **Interface modifier suppression** — new `IsInterfaceMember` guard drops the redundant `public` and `abstract` prefixes from method, property, and event signatures when the declaring type is an interface.
- **Backtick-free `FullName`** — new `TypeNameFormatter.FriendlyFullName` helper is applied to consumer-facing `FullName` emissions in `TypeAnalysisService` and `ReverseLookupService` (`FullName`, `BaseType`, `Interfaces`, `InheritanceChain`, `TypeFullName`, `DeclaringTypeFullName`, `BaseTypeChain`, `disambiguator`). `XmlDocService` and the internal type-lookup paths are intentionally left on raw `Type.FullName` since they need the canonical backtick form.

Version bumped 2.8.0 → 2.8.1.

## Test plan

- [x] `dotnet build` clean across net8.0/net9.0/net10.0
- [x] `dotnet test` — 117/117 pass on net8.0 and net10.0 (net9.0 runtime not installed locally — env gap, unrelated)
- [x] New `SignatureRenderingTests` with four `[Fact]`s covering each checklist item
- [ ] Reviewer: restart any long-running MCP server process to pick up the new `Sherlock.MCP.Runtime.dll`