### PR TITLE
perf(runtime): shared assembly contexts, mtime-aware caching, parallel reverse lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -80,3 +81,13 @@ jobs:
 
       - name: Publish to NuGet
         run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,13 +32,13 @@ This is a comprehensive .NET MCP (Model Context Protocol) server called "Sherloc
 This MCP server provides LLMs with comprehensive .NET reflection capabilities through several key architectural principles:
 
 ### Assembly-First Discovery
-Since the MCP server runs as a separate process, it cannot access the client's loaded assemblies. Instead, it provides 31+ specialized tools for clients to:
+Since the MCP server runs as a separate process, it cannot access the client's loaded assemblies. Instead, it provides 32 specialized tools for clients to:
 1. **Discover assemblies** using multiple strategies (project analysis, class name search, file system scanning)
 2. **Load and analyze** specific assemblies by path with efficient caching
 3. **Deep introspection** of types, members, attributes, and XML documentation
 4. **Performance optimization** through pagination, streaming, and response size validation
 
-### Tool Categories (31+ Available)
+### Tool Categories (32 Available)
 - **Assembly Discovery & Analysis** (3 tools): `AnalyzeAssembly`, `FindAssemblyByClassName`, `FindAssemblyByFileName`
 - **Type Introspection** (7 tools): `GetTypesFromAssembly`, `GetTypeInfo`, `GetTypeHierarchy`, etc.
 - **Member Analysis** (8 tools): `GetTypeMethods`, `GetTypeProperties`, `GetAllTypeMembers`, etc.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This tool is essential for developers who want to harness LLM capabilities for:
 
 ## Key Features
 
-*   **Comprehensive MCP Server**: Provides 31+ specialized tools for .NET assembly analysis
+*   **Comprehensive MCP Server**: Provides 32 specialized tools for .NET assembly analysis
 *   **Advanced Assembly Introspection**: Deep reflection-based analysis of types, members, and metadata
 *   **Rich Member Analysis**: Detailed inspection of methods, properties, fields, events, and constructors
 *   **Smart Filtering & Pagination**: Advanced filtering by name/attributes with efficient pagination for large datasets

--- a/src/runtime/Caching/InMemoryToolResponseCache.cs
+++ b/src/runtime/Caching/InMemoryToolResponseCache.cs
@@ -5,6 +5,16 @@ namespace Sherlock.MCP.Runtime.Caching;
 public sealed class InMemoryToolResponseCache : IToolResponseCache
 {
     private readonly ConcurrentDictionary<string, (string Payload, DateTimeOffset Expires)> _store = new();
+    private readonly RuntimeOptions? _options;
+    private int _compacting;
+
+    public InMemoryToolResponseCache()
+    {
+    }
+
+    public InMemoryToolResponseCache(RuntimeOptions options) => _options = options;
+
+    private int MaxEntries => Math.Max(16, _options?.MaxCachedResponses ?? 256);
 
     public bool TryGet(string key, out string? payload)
     {
@@ -25,6 +35,31 @@ public sealed class InMemoryToolResponseCache : IToolResponseCache
     public void Set(string key, string payload, TimeSpan ttl)
     {
         _store[key] = (payload, DateTimeOffset.UtcNow.Add(ttl));
+        if (_store.Count > MaxEntries)
+            Compact();
+    }
+
+    private void Compact()
+    {
+        if (Interlocked.CompareExchange(ref _compacting, 1, 0) != 0) return;
+        try
+        {
+            var now = DateTimeOffset.UtcNow;
+            foreach (var pair in _store)
+            {
+                if (pair.Value.Expires <= now)
+                    _store.TryRemove(pair);
+            }
+
+            var overflow = _store.Count - MaxEntries;
+            if (overflow <= 0) return;
+
+            foreach (var pair in _store.ToArray().OrderBy(p => p.Value.Expires).Take(overflow))
+                _store.TryRemove(pair);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _compacting, 0);
+        }
     }
 }
-

--- a/src/runtime/Contracts/Common/PagedResult.cs
+++ b/src/runtime/Contracts/Common/PagedResult.cs
@@ -1,0 +1,3 @@
+namespace Sherlock.MCP.Runtime.Contracts.Common;
+
+public sealed record PagedResult<T>(int Total, T[] Items);

--- a/src/runtime/IMemberAnalysisService.cs
+++ b/src/runtime/IMemberAnalysisService.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 
+using Sherlock.MCP.Runtime.Contracts.Common;
 using Sherlock.MCP.Runtime.Contracts.MemberAnalysis;
 
 namespace Sherlock.MCP.Runtime;
@@ -12,5 +13,10 @@ public interface IMemberAnalysisService
     public FieldDetails[] GetFields(string assemblyPath, string typeName, MemberFilterOptions? options = null);
     public EventDetails[] GetEvents(string assemblyPath, string typeName, MemberFilterOptions? options = null);
     public ConstructorDetails[] GetConstructors(string assemblyPath, string typeName, MemberFilterOptions? options = null);
+    public PagedResult<MethodDetails> GetMethodsPage(string assemblyPath, string typeName, MemberFilterOptions? options, int offset, int pageSize);
+    public PagedResult<PropertyDetails> GetPropertiesPage(string assemblyPath, string typeName, MemberFilterOptions? options, int offset, int pageSize);
+    public PagedResult<FieldDetails> GetFieldsPage(string assemblyPath, string typeName, MemberFilterOptions? options, int offset, int pageSize);
+    public PagedResult<EventDetails> GetEventsPage(string assemblyPath, string typeName, MemberFilterOptions? options, int offset, int pageSize);
+    public PagedResult<ConstructorDetails> GetConstructorsPage(string assemblyPath, string typeName, MemberFilterOptions? options, int offset, int pageSize);
 }
 

--- a/src/runtime/ITypeAnalysisService.cs
+++ b/src/runtime/ITypeAnalysisService.cs
@@ -12,9 +12,13 @@ public interface ITypeAnalysisService
     public TypeAnalysisInfo GetTypeInfo(Type type);
     public TypeAnalysisInfo? GetTypeInfo(string assemblyPath, string typeName);
     public TypeAnalysisHierarchy GetTypeHierarchy(Type type);
+    public TypeAnalysisHierarchy? GetTypeHierarchy(string assemblyPath, string typeName);
     public TypeAnalysisGenericTypeInfo GetGenericTypeInfo(Type type);
+    public TypeAnalysisGenericTypeInfo? GetGenericTypeInfo(string assemblyPath, string typeName);
     public TypeAnalysisAttributeInfo[] GetTypeAttributes(Type type);
+    public (string TypeFullName, TypeAnalysisAttributeInfo[] Attributes)? GetTypeAttributes(string assemblyPath, string typeName);
     public TypeAnalysisInfo[] GetNestedTypes(Type parentType);
+    public (string TypeFullName, TypeAnalysisInfo[] NestedTypes)? GetNestedTypes(string assemblyPath, string typeName);
     public TypeAnalysisInfo[] GetTypesFromAssembly(string assemblyPath);
 }
 

--- a/src/runtime/Inspection/IInspectionContextProvider.cs
+++ b/src/runtime/Inspection/IInspectionContextProvider.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+
+namespace Sherlock.MCP.Runtime.Inspection;
+
+public interface IInspectionContextProvider
+{
+    InspectionContextLease Acquire(string assemblyPath, bool forceRuntimeLoad = false);
+}
+
+public sealed class InspectionContextLease : IDisposable
+{
+    private Action? _release;
+
+    internal InspectionContextLease(IAssemblyInspectionContext context, Action release)
+    {
+        Context = context;
+        _release = release;
+    }
+
+    public IAssemblyInspectionContext Context { get; }
+
+    public Assembly Assembly => Context.Assembly;
+
+    public void Dispose() => Interlocked.Exchange(ref _release, null)?.Invoke();
+}

--- a/src/runtime/Inspection/SharedInspectionContextProvider.cs
+++ b/src/runtime/Inspection/SharedInspectionContextProvider.cs
@@ -1,0 +1,152 @@
+using System.Collections.Concurrent;
+
+namespace Sherlock.MCP.Runtime.Inspection;
+
+public sealed class SharedInspectionContextProvider : IInspectionContextProvider, IDisposable
+{
+    private sealed class Entry
+    {
+        private readonly object _gate = new();
+        private int _refCount;
+        private bool _retired;
+
+        public Entry(IAssemblyInspectionContext context, long fileStampTicks, long fileLength)
+        {
+            Context = context;
+            FileStampTicks = fileStampTicks;
+            FileLength = fileLength;
+        }
+
+        public IAssemblyInspectionContext Context { get; }
+
+        public long FileStampTicks { get; }
+
+        public long FileLength { get; }
+
+        public long LastAccess;
+
+        public bool TryAcquire()
+        {
+            lock (_gate)
+            {
+                if (_retired) return false;
+                _refCount++;
+                return true;
+            }
+        }
+
+        public void Release()
+        {
+            bool disposeNow;
+            lock (_gate)
+            {
+                _refCount--;
+                disposeNow = _retired && _refCount == 0;
+            }
+            if (disposeNow) SafeDispose();
+        }
+
+        public void Retire()
+        {
+            bool disposeNow;
+            lock (_gate)
+            {
+                if (_retired) return;
+                _retired = true;
+                disposeNow = _refCount == 0;
+            }
+            if (disposeNow) SafeDispose();
+        }
+
+        public bool IsIdle
+        {
+            get { lock (_gate) return !_retired && _refCount == 0; }
+        }
+
+        private void SafeDispose()
+        {
+            try { Context.Dispose(); } catch { }
+        }
+    }
+
+    private readonly ConcurrentDictionary<string, Lazy<Entry>> _entries = new(StringComparer.OrdinalIgnoreCase);
+    private readonly RuntimeOptions _options;
+    private long _accessCounter;
+
+    public SharedInspectionContextProvider(RuntimeOptions options) => _options = options;
+
+    public InspectionContextLease Acquire(string assemblyPath, bool forceRuntimeLoad = false)
+    {
+        var fullPath = Path.GetFullPath(assemblyPath);
+        var key = forceRuntimeLoad ? $"{fullPath}|runtime" : fullPath;
+        var fileInfo = new FileInfo(fullPath);
+        if (!fileInfo.Exists)
+            throw new FileNotFoundException($"Assembly file not found: {fullPath}", fullPath);
+
+        var stampTicks = fileInfo.LastWriteTimeUtc.Ticks;
+        var length = fileInfo.Length;
+
+        while (true)
+        {
+            var lazy = _entries.GetOrAdd(key, _ => new Lazy<Entry>(
+                () => new Entry(InspectionContextFactory.Create(fullPath, forceRuntimeLoad), stampTicks, length),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+
+            Entry entry;
+            try
+            {
+                entry = lazy.Value;
+            }
+            catch
+            {
+                _entries.TryRemove(new KeyValuePair<string, Lazy<Entry>>(key, lazy));
+                throw;
+            }
+
+            if (entry.FileStampTicks != stampTicks || entry.FileLength != length)
+            {
+                if (_entries.TryRemove(new KeyValuePair<string, Lazy<Entry>>(key, lazy)))
+                    entry.Retire();
+                continue;
+            }
+
+            if (!entry.TryAcquire())
+            {
+                _entries.TryRemove(new KeyValuePair<string, Lazy<Entry>>(key, lazy));
+                continue;
+            }
+
+            Interlocked.Exchange(ref entry.LastAccess, Interlocked.Increment(ref _accessCounter));
+            EvictOverflow();
+            return new InspectionContextLease(entry.Context, entry.Release);
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var pair in _entries.ToArray())
+        {
+            if (!_entries.TryRemove(pair)) continue;
+            if (pair.Value.IsValueCreated)
+                pair.Value.Value.Retire();
+        }
+    }
+
+    private void EvictOverflow()
+    {
+        var max = Math.Max(1, _options.MaxLoadedAssemblies);
+        if (_entries.Count <= max) return;
+
+        var idle = _entries
+            .Where(p => p.Value.IsValueCreated && p.Value.Value.IsIdle)
+            .OrderBy(p => Interlocked.Read(ref p.Value.Value.LastAccess))
+            .ToArray();
+
+        var overflow = _entries.Count - max;
+        foreach (var pair in idle.Take(overflow))
+        {
+            if (_entries.TryRemove(pair))
+                pair.Value.Value.Retire();
+        }
+    }
+}

--- a/src/runtime/MemberAnalysisService.cs
+++ b/src/runtime/MemberAnalysisService.cs
@@ -1,244 +1,245 @@
-using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text;
+using Sherlock.MCP.Runtime.Contracts.Common;
 using Sherlock.MCP.Runtime.Contracts.MemberAnalysis;
 using Sherlock.MCP.Runtime.Inspection;
 
 namespace Sherlock.MCP.Runtime;
 
-public class MemberAnalysisService : IMemberAnalysisService, IDisposable
+public class MemberAnalysisService : IMemberAnalysisService
 {
-    private readonly ConcurrentDictionary<string, IAssemblyInspectionContext> _contexts
-        = new(StringComparer.OrdinalIgnoreCase);
-    private bool _disposed;
+    private readonly IInspectionContextProvider _contexts;
 
-    private IAssemblyInspectionContext GetContext(string assemblyPath)
+    public MemberAnalysisService() : this(new SharedInspectionContextProvider(new RuntimeOptions()))
     {
-        if (_contexts.TryGetValue(assemblyPath, out var existing)) return existing;
-        var created = InspectionContextFactory.Create(assemblyPath);
-        var stored = _contexts.GetOrAdd(assemblyPath, created);
-        if (!ReferenceEquals(stored, created)) created.Dispose();
-        return stored;
     }
 
-    public void Dispose()
-    {
-        if (_disposed) return;
-        _disposed = true;
-        foreach (var ctx in _contexts.Values)
-        {
-            try { ctx.Dispose(); } catch { }
-        }
-        _contexts.Clear();
-    }
+    public MemberAnalysisService(IInspectionContextProvider contexts) => _contexts = contexts;
 
     public MemberInfo[] GetAllMembers(string assemblyPath, string typeName, MemberFilterOptions? options = null)
     {
-        var ctx = GetContext(assemblyPath);
-        var type = LoadTypeFromAssembly(ctx.Assembly, typeName, options);
+        using var lease = _contexts.Acquire(assemblyPath);
+        var type = LoadTypeFromAssembly(lease.Assembly, typeName, options);
         var bindingFlags = GetBindingFlags(options);
 
         return type.GetMembers(bindingFlags);
     }
 
     public MethodDetails[] GetMethods(string assemblyPath, string typeName, MemberFilterOptions? options = null)
-    {
-        var ctx = GetContext(assemblyPath);
-        var type = LoadTypeFromAssembly(ctx.Assembly, typeName, options);
-        var bindingFlags = GetBindingFlags(options);
-        var methods = type.GetMethods(bindingFlags);
-
-        var methodDetails = new List<MethodDetails>();
-        foreach (var method in methods)
-        {
-            if (method.IsSpecialName && (method.Name.StartsWith("get_") || method.Name.StartsWith("set_") || 
-                method.Name.StartsWith("add_") || method.Name.StartsWith("remove_")))
-            {
-                continue;
-            }
-
-            var parameters = GetParameterDetails(method.GetParameters());
-            var genericParams = method.IsGenericMethodDefinition ? 
-                method.GetGenericArguments().Select(t => t.Name).ToArray() : 
-                Array.Empty<string>();
-            var isOperator = IsOperatorMethod(method);
-            var isExtensionMethod = IsExtensionMethod(method);
-            var signature = BuildMethodSignature(method, parameters, genericParams);
-            var customAttributes = AttributeUtils.FromMember(method);
-
-            methodDetails.Add(new MethodDetails(
-                Name: method.Name,
-                ReturnTypeName: GetFriendlyTypeName(method.ReturnType),
-                Parameters: parameters,
-                GenericTypeParameters: genericParams,
-                Attributes: method.Attributes,
-                AccessModifier: GetAccessModifier(method),
-                IsStatic: method.IsStatic,
-                IsVirtual: method.IsVirtual && !method.IsFinal,
-                IsAbstract: method.IsAbstract,
-                IsSealed: method.IsFinal && method.IsVirtual,
-                IsOverride: IsOverrideMethod(method),
-                IsOperator: isOperator,
-                IsExtensionMethod: isExtensionMethod,
-                CustomAttributes: customAttributes,
-                Signature: signature
-            ));
-        }
-
-        return ApplyMemberFilters(methodDetails, options, m => m.Name, m => m.CustomAttributes).ToArray();
-    }
+        => GetMethodsPage(assemblyPath, typeName, options, options?.Skip ?? 0, options?.Take ?? int.MaxValue).Items;
 
     public PropertyDetails[] GetProperties(string assemblyPath, string typeName, MemberFilterOptions? options = null)
-    {
-        var ctx = GetContext(assemblyPath);
-        var type = LoadTypeFromAssembly(ctx.Assembly, typeName, options);
-        var bindingFlags = GetBindingFlags(options);
-        var properties = type.GetProperties(bindingFlags);
-
-        var propertyDetails = new List<PropertyDetails>();
-        foreach (var property in properties)
-        {
-            var indexerParams = GetParameterDetails(property.GetIndexParameters());
-            var isIndexer = indexerParams.Length > 0;
-            var getMethod = property.GetGetMethod(true);
-            var setMethod = property.GetSetMethod(true);
-            var getterAccessModifier = getMethod != null ? GetAccessModifier(getMethod) : null;
-            var setterAccessModifier = setMethod != null ? GetAccessModifier(setMethod) : null;
-            var primaryMethod = getMethod ?? setMethod;
-            var signature = BuildPropertySignature(property, indexerParams);
-            var customAttributes = AttributeUtils.FromMember(property);
-
-            propertyDetails.Add(new PropertyDetails(
-                Name: property.Name,
-                TypeName: GetFriendlyTypeName(property.PropertyType),
-                Attributes: property.Attributes,
-                AccessModifier: primaryMethod != null ? GetAccessModifier(primaryMethod) : "private",
-                IsStatic: primaryMethod?.IsStatic ?? false,
-                IsVirtual: primaryMethod?.IsVirtual == true && !primaryMethod.IsFinal,
-                IsAbstract: primaryMethod?.IsAbstract ?? false,
-                IsSealed: primaryMethod?.IsFinal == true && primaryMethod?.IsVirtual == true,
-                IsOverride: primaryMethod != null && IsOverrideMethod(primaryMethod),
-                CanRead: property.CanRead,
-                CanWrite: property.CanWrite,
-                IsIndexer: isIndexer,
-                IndexerParameters: indexerParams,
-                GetterAccessModifier: getterAccessModifier,
-                SetterAccessModifier: setterAccessModifier,
-                CustomAttributes: customAttributes,
-                Signature: signature
-            ));
-        }
-
-        return ApplyMemberFilters(propertyDetails, options, p => p.Name, p => p.CustomAttributes).ToArray();
-    }
+        => GetPropertiesPage(assemblyPath, typeName, options, options?.Skip ?? 0, options?.Take ?? int.MaxValue).Items;
 
     public FieldDetails[] GetFields(string assemblyPath, string typeName, MemberFilterOptions? options = null)
-    {
-        var ctx = GetContext(assemblyPath);
-        var type = LoadTypeFromAssembly(ctx.Assembly, typeName, options);
-        var bindingFlags = GetBindingFlags(options);
-        var fields = type.GetFields(bindingFlags);
-
-        var fieldDetails = new List<FieldDetails>();
-        foreach (var field in fields)
-        {
-            object? constantValue = null;
-            if (field.IsLiteral && !field.IsInitOnly)
-            {
-                try
-                {
-                    constantValue = field.GetRawConstantValue();
-                }
-                catch
-                {
-                }
-            }
-
-            var signature = BuildFieldSignature(field);
-            var customAttributes = AttributeUtils.FromMember(field);
-
-            fieldDetails.Add(new FieldDetails(
-                Name: field.Name,
-                TypeName: GetFriendlyTypeName(field.FieldType),
-                Attributes: field.Attributes,
-                AccessModifier: GetAccessModifier(field),
-                IsStatic: field.IsStatic,
-                IsReadOnly: field.IsInitOnly,
-                IsConst: field.IsLiteral && !field.IsInitOnly,
-                IsVolatile: IsVolatileField(field),
-                IsInitOnly: field.IsInitOnly,
-                ConstantValue: constantValue,
-                CustomAttributes: customAttributes,
-                Signature: signature
-            ));
-        }
-
-        return ApplyMemberFilters(fieldDetails, options, f => f.Name, f => f.CustomAttributes).ToArray();
-    }
+        => GetFieldsPage(assemblyPath, typeName, options, options?.Skip ?? 0, options?.Take ?? int.MaxValue).Items;
 
     public EventDetails[] GetEvents(string assemblyPath, string typeName, MemberFilterOptions? options = null)
-    {
-        var ctx = GetContext(assemblyPath);
-        var type = LoadTypeFromAssembly(ctx.Assembly, typeName, options);
-        var bindingFlags = GetBindingFlags(options);
-        var events = type.GetEvents(bindingFlags);
-
-        var eventDetails = new List<EventDetails>();
-        foreach (var eventInfo in events)
-        {
-            var addMethod = eventInfo.GetAddMethod(true);
-            var removeMethod = eventInfo.GetRemoveMethod(true);
-            var addMethodAccessModifier = addMethod != null ? GetAccessModifier(addMethod) : null;
-            var removeMethodAccessModifier = removeMethod != null ? GetAccessModifier(removeMethod) : null;
-            var primaryMethod = addMethod ?? removeMethod;
-            var signature = BuildEventSignature(eventInfo);
-            var customAttributes = AttributeUtils.FromMember(eventInfo);
-
-            eventDetails.Add(new EventDetails(
-                Name: eventInfo.Name,
-                EventHandlerTypeName: GetFriendlyTypeName(eventInfo.EventHandlerType!),
-                Attributes: eventInfo.Attributes,
-                AccessModifier: primaryMethod != null ? GetAccessModifier(primaryMethod) : "private",
-                IsStatic: primaryMethod?.IsStatic ?? false,
-                IsVirtual: primaryMethod?.IsVirtual == true && !primaryMethod.IsFinal,
-                IsAbstract: primaryMethod?.IsAbstract ?? false,
-                IsSealed: primaryMethod?.IsFinal == true && primaryMethod?.IsVirtual == true,
-                IsOverride: primaryMethod != null && IsOverrideMethod(primaryMethod),
-                AddMethodAccessModifier: addMethodAccessModifier,
-                RemoveMethodAccessModifier: removeMethodAccessModifier,
-                CustomAttributes: customAttributes,
-                Signature: signature
-            ));
-        }
-
-        return ApplyMemberFilters(eventDetails, options, e => e.Name, e => e.CustomAttributes).ToArray();
-    }
+        => GetEventsPage(assemblyPath, typeName, options, options?.Skip ?? 0, options?.Take ?? int.MaxValue).Items;
 
     public ConstructorDetails[] GetConstructors(string assemblyPath, string typeName, MemberFilterOptions? options = null)
+        => GetConstructorsPage(assemblyPath, typeName, options, options?.Skip ?? 0, options?.Take ?? int.MaxValue).Items;
+
+    public PagedResult<MethodDetails> GetMethodsPage(string assemblyPath, string typeName, MemberFilterOptions? options, int offset, int pageSize)
     {
-        var ctx = GetContext(assemblyPath);
-        var type = LoadTypeFromAssembly(ctx.Assembly, typeName, options);
-        var bindingFlags = GetBindingFlags(options);
-        var constructors = type.GetConstructors(bindingFlags);
+        using var lease = _contexts.Acquire(assemblyPath);
+        var type = LoadTypeFromAssembly(lease.Assembly, typeName, options);
+        var methods = type.GetMethods(GetBindingFlags(options))
+            .Where(m => !IsAccessorMethod(m));
 
-        var constructorDetails = new List<ConstructorDetails>();
-        foreach (var constructor in constructors)
+        var filtered = FilterAndSortMembers(methods, options);
+        return BuildPage(filtered, offset, pageSize, BuildMethodDetails);
+    }
+
+    public PagedResult<PropertyDetails> GetPropertiesPage(string assemblyPath, string typeName, MemberFilterOptions? options, int offset, int pageSize)
+    {
+        using var lease = _contexts.Acquire(assemblyPath);
+        var type = LoadTypeFromAssembly(lease.Assembly, typeName, options);
+        var filtered = FilterAndSortMembers(type.GetProperties(GetBindingFlags(options)), options);
+        return BuildPage(filtered, offset, pageSize, BuildPropertyDetails);
+    }
+
+    public PagedResult<FieldDetails> GetFieldsPage(string assemblyPath, string typeName, MemberFilterOptions? options, int offset, int pageSize)
+    {
+        using var lease = _contexts.Acquire(assemblyPath);
+        var type = LoadTypeFromAssembly(lease.Assembly, typeName, options);
+        var filtered = FilterAndSortMembers(type.GetFields(GetBindingFlags(options)), options);
+        return BuildPage(filtered, offset, pageSize, BuildFieldDetails);
+    }
+
+    public PagedResult<EventDetails> GetEventsPage(string assemblyPath, string typeName, MemberFilterOptions? options, int offset, int pageSize)
+    {
+        using var lease = _contexts.Acquire(assemblyPath);
+        var type = LoadTypeFromAssembly(lease.Assembly, typeName, options);
+        var filtered = FilterAndSortMembers(type.GetEvents(GetBindingFlags(options)), options);
+        return BuildPage(filtered, offset, pageSize, BuildEventDetails);
+    }
+
+    public PagedResult<ConstructorDetails> GetConstructorsPage(string assemblyPath, string typeName, MemberFilterOptions? options, int offset, int pageSize)
+    {
+        using var lease = _contexts.Acquire(assemblyPath);
+        var type = LoadTypeFromAssembly(lease.Assembly, typeName, options);
+        var all = type.GetConstructors(GetBindingFlags(options))
+            .Select(BuildConstructorDetails);
+
+        // Constructors sort and filter by full signature, so details are built before paging; counts stay tiny.
+        var filtered = FilterAndSortDetails(all, options, c => c.Signature, c => c.CustomAttributes).ToArray();
+        var items = filtered.Skip(Math.Max(0, offset)).Take(Math.Max(0, pageSize)).ToArray();
+        return new PagedResult<ConstructorDetails>(filtered.Length, items);
+    }
+
+    private static PagedResult<TDetails> BuildPage<TMember, TDetails>(IReadOnlyList<TMember> filtered, int offset, int pageSize, Func<TMember, TDetails> build)
+        where TMember : MemberInfo
+    {
+        var items = filtered
+            .Skip(Math.Max(0, offset))
+            .Take(Math.Max(0, pageSize))
+            .Select(build)
+            .ToArray();
+        return new PagedResult<TDetails>(filtered.Count, items);
+    }
+
+    private static bool IsAccessorMethod(MethodInfo method) =>
+        method.IsSpecialName && (method.Name.StartsWith("get_") || method.Name.StartsWith("set_") ||
+            method.Name.StartsWith("add_") || method.Name.StartsWith("remove_"));
+
+    private static MethodDetails BuildMethodDetails(MethodInfo method)
+    {
+        var parameters = GetParameterDetails(method.GetParameters());
+        var genericParams = method.IsGenericMethodDefinition ?
+            method.GetGenericArguments().Select(t => t.Name).ToArray() :
+            Array.Empty<string>();
+        var isOperator = IsOperatorMethod(method);
+        var isExtensionMethod = IsExtensionMethod(method);
+        var signature = BuildMethodSignature(method, parameters, genericParams);
+        var customAttributes = AttributeUtils.FromMember(method);
+
+        return new MethodDetails(
+            Name: method.Name,
+            ReturnTypeName: GetFriendlyTypeName(method.ReturnType),
+            Parameters: parameters,
+            GenericTypeParameters: genericParams,
+            Attributes: method.Attributes,
+            AccessModifier: GetAccessModifier(method),
+            IsStatic: method.IsStatic,
+            IsVirtual: method.IsVirtual && !method.IsFinal,
+            IsAbstract: method.IsAbstract,
+            IsSealed: method.IsFinal && method.IsVirtual,
+            IsOverride: IsOverrideMethod(method),
+            IsOperator: isOperator,
+            IsExtensionMethod: isExtensionMethod,
+            CustomAttributes: customAttributes,
+            Signature: signature
+        );
+    }
+
+    private static PropertyDetails BuildPropertyDetails(PropertyInfo property)
+    {
+        var indexerParams = GetParameterDetails(property.GetIndexParameters());
+        var isIndexer = indexerParams.Length > 0;
+        var getMethod = property.GetGetMethod(true);
+        var setMethod = property.GetSetMethod(true);
+        var getterAccessModifier = getMethod != null ? GetAccessModifier(getMethod) : null;
+        var setterAccessModifier = setMethod != null ? GetAccessModifier(setMethod) : null;
+        var primaryMethod = getMethod ?? setMethod;
+        var signature = BuildPropertySignature(property, indexerParams);
+        var customAttributes = AttributeUtils.FromMember(property);
+
+        return new PropertyDetails(
+            Name: property.Name,
+            TypeName: GetFriendlyTypeName(property.PropertyType),
+            Attributes: property.Attributes,
+            AccessModifier: primaryMethod != null ? GetAccessModifier(primaryMethod) : "private",
+            IsStatic: primaryMethod?.IsStatic ?? false,
+            IsVirtual: primaryMethod?.IsVirtual == true && !primaryMethod.IsFinal,
+            IsAbstract: primaryMethod?.IsAbstract ?? false,
+            IsSealed: primaryMethod?.IsFinal == true && primaryMethod?.IsVirtual == true,
+            IsOverride: primaryMethod != null && IsOverrideMethod(primaryMethod),
+            CanRead: property.CanRead,
+            CanWrite: property.CanWrite,
+            IsIndexer: isIndexer,
+            IndexerParameters: indexerParams,
+            GetterAccessModifier: getterAccessModifier,
+            SetterAccessModifier: setterAccessModifier,
+            CustomAttributes: customAttributes,
+            Signature: signature
+        );
+    }
+
+    private static FieldDetails BuildFieldDetails(FieldInfo field)
+    {
+        object? constantValue = null;
+        if (field.IsLiteral && !field.IsInitOnly)
         {
-            var parameters = GetParameterDetails(constructor.GetParameters());
-            var signature = BuildConstructorSignature(constructor, parameters);
-            var customAttributes = AttributeUtils.FromMember(constructor);
-
-            constructorDetails.Add(new ConstructorDetails(
-                Parameters: parameters,
-                Attributes: constructor.Attributes,
-                AccessModifier: GetAccessModifier(constructor),
-                IsStatic: constructor.IsStatic,
-                CustomAttributes: customAttributes,
-                Signature: signature
-            ));
+            try
+            {
+                constantValue = field.GetRawConstantValue();
+            }
+            catch
+            {
+            }
         }
 
-        return ApplyMemberFilters(constructorDetails, options, c => c.Signature, c => c.CustomAttributes).ToArray();
+        var signature = BuildFieldSignature(field);
+        var customAttributes = AttributeUtils.FromMember(field);
+
+        return new FieldDetails(
+            Name: field.Name,
+            TypeName: GetFriendlyTypeName(field.FieldType),
+            Attributes: field.Attributes,
+            AccessModifier: GetAccessModifier(field),
+            IsStatic: field.IsStatic,
+            IsReadOnly: field.IsInitOnly,
+            IsConst: field.IsLiteral && !field.IsInitOnly,
+            IsVolatile: IsVolatileField(field),
+            IsInitOnly: field.IsInitOnly,
+            ConstantValue: constantValue,
+            CustomAttributes: customAttributes,
+            Signature: signature
+        );
+    }
+
+    private static EventDetails BuildEventDetails(EventInfo eventInfo)
+    {
+        var addMethod = eventInfo.GetAddMethod(true);
+        var removeMethod = eventInfo.GetRemoveMethod(true);
+        var addMethodAccessModifier = addMethod != null ? GetAccessModifier(addMethod) : null;
+        var removeMethodAccessModifier = removeMethod != null ? GetAccessModifier(removeMethod) : null;
+        var primaryMethod = addMethod ?? removeMethod;
+        var signature = BuildEventSignature(eventInfo);
+        var customAttributes = AttributeUtils.FromMember(eventInfo);
+
+        return new EventDetails(
+            Name: eventInfo.Name,
+            EventHandlerTypeName: GetFriendlyTypeName(eventInfo.EventHandlerType!),
+            Attributes: eventInfo.Attributes,
+            AccessModifier: primaryMethod != null ? GetAccessModifier(primaryMethod) : "private",
+            IsStatic: primaryMethod?.IsStatic ?? false,
+            IsVirtual: primaryMethod?.IsVirtual == true && !primaryMethod.IsFinal,
+            IsAbstract: primaryMethod?.IsAbstract ?? false,
+            IsSealed: primaryMethod?.IsFinal == true && primaryMethod?.IsVirtual == true,
+            IsOverride: primaryMethod != null && IsOverrideMethod(primaryMethod),
+            AddMethodAccessModifier: addMethodAccessModifier,
+            RemoveMethodAccessModifier: removeMethodAccessModifier,
+            CustomAttributes: customAttributes,
+            Signature: signature
+        );
+    }
+
+    private static ConstructorDetails BuildConstructorDetails(ConstructorInfo constructor)
+    {
+        var parameters = GetParameterDetails(constructor.GetParameters());
+        var signature = BuildConstructorSignature(constructor, parameters);
+        var customAttributes = AttributeUtils.FromMember(constructor);
+
+        return new ConstructorDetails(
+            Parameters: parameters,
+            Attributes: constructor.Attributes,
+            AccessModifier: GetAccessModifier(constructor),
+            IsStatic: constructor.IsStatic,
+            CustomAttributes: customAttributes,
+            Signature: signature
+        );
     }
 
     private static Type LoadTypeFromAssembly(Assembly assembly, string typeName, MemberFilterOptions? options)
@@ -339,7 +340,36 @@ public class MemberAnalysisService : IMemberAnalysisService, IDisposable
         _ => c.ToString()
     };
 
-    private static IEnumerable<T> ApplyMemberFilters<T>(IEnumerable<T> source, MemberFilterOptions? options, Func<T, string> nameSelector, Func<T, Sherlock.MCP.Runtime.Contracts.TypeAnalysis.AttributeInfo[]> attrSelector)
+    private static List<T> FilterAndSortMembers<T>(IEnumerable<T> source, MemberFilterOptions? options) where T : MemberInfo
+    {
+        options ??= new MemberFilterOptions();
+        var comparison = options.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        var query = source;
+
+        if (!string.IsNullOrEmpty(options.NameContains))
+        {
+            query = query.Where(m => m.Name.IndexOf(options.NameContains!, comparison) >= 0);
+        }
+        if (!string.IsNullOrEmpty(options.HasAttributeContains))
+        {
+            query = query.Where(m => HasAttributeMatch(m, options.HasAttributeContains!, comparison));
+        }
+
+        var descending = options.SortOrder.Equals("desc", StringComparison.OrdinalIgnoreCase);
+        var ordered = options.SortBy.ToLowerInvariant() switch
+        {
+            "access" => descending
+                ? query.OrderByDescending(AccessModifierOf).ThenByDescending(m => m.Name)
+                : query.OrderBy(AccessModifierOf).ThenBy(m => m.Name),
+            _ => descending
+                ? query.OrderByDescending(m => m.Name)
+                : query.OrderBy(m => m.Name)
+        };
+
+        return ordered.ToList();
+    }
+
+    private static IEnumerable<T> FilterAndSortDetails<T>(IEnumerable<T> source, MemberFilterOptions? options, Func<T, string> nameSelector, Func<T, Sherlock.MCP.Runtime.Contracts.TypeAnalysis.AttributeInfo[]> attrSelector)
     {
         options ??= new MemberFilterOptions();
         var comparison = options.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
@@ -354,76 +384,32 @@ public class MemberAnalysisService : IMemberAnalysisService, IDisposable
             query = query.Where(x => attrSelector(x).Any(a => (a.AttributeType?.IndexOf(options.HasAttributeContains!, comparison) ?? -1) >= 0));
         }
 
-        query = options.SortBy.ToLowerInvariant() switch
-        {
-            _ => (options.SortOrder.Equals("desc", StringComparison.OrdinalIgnoreCase)
-                ? query.OrderByDescending(x => nameSelector(x))
-                : query.OrderBy(x => nameSelector(x)))
-        };
-
-        if (options.Skip.HasValue) query = query.Skip(Math.Max(0, options.Skip.Value));
-        if (options.Take.HasValue) query = query.Take(Math.Max(0, options.Take.Value));
-
-        return query;
+        return options.SortOrder.Equals("desc", StringComparison.OrdinalIgnoreCase)
+            ? query.OrderByDescending(nameSelector)
+            : query.OrderBy(nameSelector);
     }
 
-    private static string GetFriendlyTypeName(Type type)
+    private static bool HasAttributeMatch(MemberInfo member, string filter, StringComparison comparison)
     {
-        if (type.IsByRef)
+        try
         {
-            return GetFriendlyTypeName(type.GetElementType()!) + "&";
+            return member.GetCustomAttributesData()
+                .Any(a => (a.AttributeType.FullName ?? a.AttributeType.Name).IndexOf(filter, comparison) >= 0);
         }
-        if (type.IsPointer)
+        catch
         {
-            return GetFriendlyTypeName(type.GetElementType()!) + "*";
+            return false;
         }
-        if (type.IsArray)
-        {
-            var elementType = GetFriendlyTypeName(type.GetElementType()!);
-            var rank = type.GetArrayRank();
-            var brackets = rank == 1 ? "[]" : "[" + new string(',', rank - 1) + "]";
-            return elementType + brackets;
-        }
-        if (type.IsGenericType && !type.IsGenericTypeDefinition && type.GetGenericTypeDefinition().FullName == "System.Nullable`1")
-        {
-            return GetFriendlyTypeName(type.GetGenericArguments()[0]) + "?";
-        }
-        if (type.IsGenericType)
-        {
-            var genericTypeDef = type.GetGenericTypeDefinition();
-            var friendlyName = genericTypeDef.Name;
-            var backtickIndex = friendlyName.IndexOf('`');
-            if (backtickIndex > 0)
-            {
-                friendlyName = friendlyName.Substring(0, backtickIndex);
-            }
-            var genericArgs = type.GetGenericArguments().Select(GetFriendlyTypeName);
-            return $"{friendlyName}<{string.Join(", ", genericArgs)}>";
-        }
-        return type.FullName is string fullName && BuiltInTypeNames.TryGetValue(fullName, out var builtInName)
-            ? builtInName
-            : type.Name;
     }
 
-    private static readonly Dictionary<string, string> BuiltInTypeNames = new(StringComparer.Ordinal)
+    private static string AccessModifierOf(MemberInfo member) => member switch
     {
-        ["System.Boolean"] = "bool",
-        ["System.Byte"] = "byte",
-        ["System.SByte"] = "sbyte",
-        ["System.Char"] = "char",
-        ["System.Decimal"] = "decimal",
-        ["System.Double"] = "double",
-        ["System.Single"] = "float",
-        ["System.Int32"] = "int",
-        ["System.UInt32"] = "uint",
-        ["System.Int64"] = "long",
-        ["System.UInt64"] = "ulong",
-        ["System.Int16"] = "short",
-        ["System.UInt16"] = "ushort",
-        ["System.Object"] = "object",
-        ["System.String"] = "string",
-        ["System.Void"] = "void"
+        PropertyInfo property => (property.GetGetMethod(true) ?? property.GetSetMethod(true)) is { } accessor ? GetAccessModifier(accessor) : "private",
+        EventInfo eventInfo => (eventInfo.GetAddMethod(true) ?? eventInfo.GetRemoveMethod(true)) is { } accessor ? GetAccessModifier(accessor) : "private",
+        _ => GetAccessModifier(member)
     };
+
+    private static string GetFriendlyTypeName(Type type) => TypeNameFormatter.FriendlyName(type);
 
     private static string GetAccessModifier(MemberInfo member)
     {
@@ -446,7 +432,7 @@ public class MemberAnalysisService : IMemberAnalysisService, IDisposable
     }
     private static bool IsOperatorMethod(MethodInfo method)
     {
-        return method.IsSpecialName && method.IsStatic && 
+        return method.IsSpecialName && method.IsStatic &&
                (method.Name.StartsWith("op_") || method.Name == "True" || method.Name == "False");
     }
     private static bool IsExtensionMethod(MethodInfo method)

--- a/src/runtime/ReverseLookupService.cs
+++ b/src/runtime/ReverseLookupService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using Sherlock.MCP.Runtime.Contracts.ReverseLookup;
 using Sherlock.MCP.Runtime.Inspection;
@@ -6,40 +7,44 @@ namespace Sherlock.MCP.Runtime;
 
 public class ReverseLookupService : IReverseLookupService
 {
+    private readonly IInspectionContextProvider _contexts;
+
+    public ReverseLookupService() : this(new SharedInspectionContextProvider(new RuntimeOptions()))
+    {
+    }
+
+    public ReverseLookupService(IInspectionContextProvider contexts) => _contexts = contexts;
+
     public ImplementationHit[] FindImplementations(string[] assemblyPaths, string typeName, ReverseLookupOptions options)
     {
-        var hits = new List<ImplementationHit>();
+        var hits = new ConcurrentBag<ImplementationHit>();
 
-        foreach (var path in assemblyPaths)
+        ScanInParallel(assemblyPaths, (path, ctx) =>
         {
-            if (!File.Exists(path)) continue;
-            if (!TryScanAssembly(path, ctx =>
+            foreach (var candidate in GetScannableTypes(ctx, options))
             {
-                foreach (var candidate in GetScannableTypes(ctx, options))
-                {
-                    var matchedInterfaces = GetInterfacesSafe(candidate)
-                        .Where(i => TypeNameMatcher.Matches(i, typeName, options.CaseSensitive))
-                        .Select(TypeNameFormatter.FriendlyFullName)
-                        .ToArray();
+                var matchedInterfaces = GetInterfacesSafe(candidate)
+                    .Where(i => TypeNameMatcher.Matches(i, typeName, options.CaseSensitive))
+                    .Select(TypeNameFormatter.FriendlyFullName)
+                    .ToArray();
 
-                    var baseTypeChain = GetBaseTypeChain(candidate);
-                    var matchedBases = baseTypeChain
-                        .Where(b => TypeNameMatcher.Matches(b, typeName, options.CaseSensitive))
-                        .Select(TypeNameFormatter.FriendlyFullName)
-                        .ToArray();
+                var baseTypeChain = GetBaseTypeChain(candidate);
+                var matchedBases = baseTypeChain
+                    .Where(b => TypeNameMatcher.Matches(b, typeName, options.CaseSensitive))
+                    .Select(TypeNameFormatter.FriendlyFullName)
+                    .ToArray();
 
-                    if (matchedInterfaces.Length == 0 && matchedBases.Length == 0) continue;
+                if (matchedInterfaces.Length == 0 && matchedBases.Length == 0) continue;
 
-                    var kind = matchedInterfaces.Length > 0 ? "interface" : "baseType";
-                    hits.Add(new ImplementationHit(
-                        AssemblyPath: path,
-                        TypeFullName: TypeNameFormatter.FriendlyFullName(candidate),
-                        Kind: kind,
-                        MatchedInterfaces: matchedInterfaces,
-                        BaseTypeChain: baseTypeChain.Select(TypeNameFormatter.FriendlyFullName).ToArray()));
-                }
-            })) continue;
-        }
+                var kind = matchedInterfaces.Length > 0 ? "interface" : "baseType";
+                hits.Add(new ImplementationHit(
+                    AssemblyPath: path,
+                    TypeFullName: TypeNameFormatter.FriendlyFullName(candidate),
+                    Kind: kind,
+                    MatchedInterfaces: matchedInterfaces,
+                    BaseTypeChain: baseTypeChain.Select(TypeNameFormatter.FriendlyFullName).ToArray()));
+            }
+        });
 
         return hits
             .OrderBy(h => h.AssemblyPath, StringComparer.Ordinal)
@@ -49,35 +54,31 @@ public class ReverseLookupService : IReverseLookupService
 
     public MethodReturnHit[] FindMethodsReturning(string[] assemblyPaths, string typeName, ReverseLookupOptions options)
     {
-        var hits = new List<MethodReturnHit>();
+        var hits = new ConcurrentBag<MethodReturnHit>();
         var flags = BuildMemberFlags(options);
 
-        foreach (var path in assemblyPaths)
+        ScanInParallel(assemblyPaths, (path, ctx) =>
         {
-            if (!File.Exists(path)) continue;
-            if (!TryScanAssembly(path, ctx =>
+            foreach (var candidate in GetScannableTypes(ctx, options))
             {
-                foreach (var candidate in GetScannableTypes(ctx, options))
+                foreach (var method in GetMethodsSafe(candidate, flags))
                 {
-                    foreach (var method in GetMethodsSafe(candidate, flags))
-                    {
-                        Type? returnType;
-                        try { returnType = method.ReturnType; }
-                        catch { continue; }
+                    Type? returnType;
+                    try { returnType = method.ReturnType; }
+                    catch { continue; }
 
-                        if (!TypeNameMatcher.Matches(returnType, typeName, options.CaseSensitive)) continue;
+                    if (!TypeNameMatcher.Matches(returnType, typeName, options.CaseSensitive)) continue;
 
-                        hits.Add(new MethodReturnHit(
-                            AssemblyPath: path,
-                            DeclaringTypeFullName: TypeNameFormatter.FriendlyFullName(candidate),
-                            MethodName: method.Name,
-                            Signature: FormatMethodSignature(method),
-                            ReturnTypeFriendlyName: FriendlyTypeName(returnType),
-                            IsStatic: method.IsStatic));
-                    }
+                    hits.Add(new MethodReturnHit(
+                        AssemblyPath: path,
+                        DeclaringTypeFullName: TypeNameFormatter.FriendlyFullName(candidate),
+                        MethodName: method.Name,
+                        Signature: FormatMethodSignature(method),
+                        ReturnTypeFriendlyName: FriendlyTypeName(returnType),
+                        IsStatic: method.IsStatic));
                 }
-            })) continue;
-        }
+            }
+        });
 
         return hits
             .OrderBy(h => h.AssemblyPath, StringComparer.Ordinal)
@@ -89,29 +90,28 @@ public class ReverseLookupService : IReverseLookupService
 
     public ReferencesResult FindReferences(string[] assemblyPaths, string typeName, ReverseLookupOptions options)
     {
-        var hits = new List<ReferenceHit>();
+        var hits = new ConcurrentBag<ReferenceHit>();
         var flags = BuildMemberFlags(options);
         var cap = Math.Max(1, options.HardCap);
-        var truncated = false;
+        var reserved = 0;
+        var truncated = 0;
 
-        foreach (var path in assemblyPaths)
+        bool TryAdd(ReferenceHit hit)
         {
-            if (truncated) break;
-            if (!File.Exists(path)) continue;
-
-            IAssemblyInspectionContext? ctx;
-            try { ctx = InspectionContextFactory.Create(path); }
-            catch (BadImageFormatException) { continue; }
-            catch (FileLoadException) { continue; }
-            catch (ReflectionTypeLoadException) { continue; }
-            catch (IOException) { continue; }
-
-            using (ctx)
-            try
+            if (Interlocked.Increment(ref reserved) > cap)
             {
+                Interlocked.Exchange(ref truncated, 1);
+                return false;
+            }
+            hits.Add(hit);
+            return true;
+        }
+
+        ScanInParallel(assemblyPaths, (path, ctx) =>
+        {
             foreach (var candidate in GetScannableTypes(ctx, options))
             {
-                if (hits.Count >= cap) { truncated = true; break; }
+                if (Volatile.Read(ref truncated) == 1) return;
 
                 var declaringName = TypeNameFormatter.FriendlyFullName(candidate);
 
@@ -119,21 +119,18 @@ public class ReverseLookupService : IReverseLookupService
                 try { baseType = candidate.BaseType; } catch { }
                 if (baseType != null && TypeNameMatcher.Matches(baseType, typeName, options.CaseSensitive))
                 {
-                    hits.Add(MakeRefHit(path, declaringName, "type", declaringName, "baseType",
+                    if (!TryAdd(MakeRefHit(path, declaringName, "type", declaringName, "baseType",
                         $"{declaringName} : {FriendlyTypeName(baseType)}",
-                        disambiguator: TypeNameFormatter.FriendlyFullName(baseType)));
+                        disambiguator: TypeNameFormatter.FriendlyFullName(baseType)))) return;
                 }
 
                 foreach (var iface in GetInterfacesSafe(candidate))
                 {
-                    if (hits.Count >= cap) { truncated = true; break; }
                     if (!TypeNameMatcher.Matches(iface, typeName, options.CaseSensitive)) continue;
-                    hits.Add(MakeRefHit(path, declaringName, "type", declaringName, "interface",
+                    if (!TryAdd(MakeRefHit(path, declaringName, "type", declaringName, "interface",
                         $"{declaringName} : {FriendlyTypeName(iface)}",
-                        disambiguator: TypeNameFormatter.FriendlyFullName(iface)));
+                        disambiguator: TypeNameFormatter.FriendlyFullName(iface)))) return;
                 }
-
-                if (truncated) break;
 
                 if (candidate.IsGenericType)
                 {
@@ -141,18 +138,15 @@ public class ReverseLookupService : IReverseLookupService
                     try { args = candidate.GetGenericArguments(); } catch { args = Array.Empty<Type>(); }
                     foreach (var arg in args)
                     {
-                        if (hits.Count >= cap) { truncated = true; break; }
                         if (!TypeNameMatcher.Matches(arg, typeName, options.CaseSensitive)) continue;
-                        hits.Add(MakeRefHit(path, declaringName, "type", declaringName, "genericArg",
+                        if (!TryAdd(MakeRefHit(path, declaringName, "type", declaringName, "genericArg",
                             $"{declaringName}<{FriendlyTypeName(arg)}>",
-                            disambiguator: TypeNameFormatter.FriendlyFullName(arg)));
+                            disambiguator: TypeNameFormatter.FriendlyFullName(arg)))) return;
                     }
-                    if (truncated) break;
                 }
 
                 foreach (var method in GetMethodsSafe(candidate, flags))
                 {
-                    if (hits.Count >= cap) { truncated = true; break; }
                     var sig = FormatMethodSignature(method);
 
                     Type? returnType = null;
@@ -160,71 +154,56 @@ public class ReverseLookupService : IReverseLookupService
                     var returnMatch = FindMatchingType(returnType, typeName, options.CaseSensitive);
                     if (returnMatch != null)
                     {
-                        hits.Add(MakeRefHit(path, declaringName, "method", method.Name, "return", sig,
-                            disambiguator: TypeNameFormatter.FriendlyFullName(returnMatch)));
+                        if (!TryAdd(MakeRefHit(path, declaringName, "method", method.Name, "return", sig,
+                            disambiguator: TypeNameFormatter.FriendlyFullName(returnMatch)))) return;
                     }
 
                     ParameterInfo[] parameters;
                     try { parameters = method.GetParameters(); } catch { parameters = Array.Empty<ParameterInfo>(); }
                     foreach (var p in parameters)
                     {
-                        if (hits.Count >= cap) { truncated = true; break; }
                         Type? pt;
                         try { pt = p.ParameterType; } catch { continue; }
                         if (FindMatchingType(pt, typeName, options.CaseSensitive) == null) continue;
-                        hits.Add(MakeRefHit(path, declaringName, "method", method.Name, "parameter", sig,
-                            disambiguator: p.Name ?? p.Position.ToString()));
+                        if (!TryAdd(MakeRefHit(path, declaringName, "method", method.Name, "parameter", sig,
+                            disambiguator: p.Name ?? p.Position.ToString()))) return;
                     }
                 }
 
-                if (truncated) break;
-
                 foreach (var prop in GetPropertiesSafe(candidate, flags))
                 {
-                    if (hits.Count >= cap) { truncated = true; break; }
                     Type? pt;
                     try { pt = prop.PropertyType; } catch { continue; }
                     var propMatch = FindMatchingType(pt, typeName, options.CaseSensitive);
                     if (propMatch == null) continue;
-                    hits.Add(MakeRefHit(path, declaringName, "property", prop.Name, "property",
+                    if (!TryAdd(MakeRefHit(path, declaringName, "property", prop.Name, "property",
                         $"{FriendlyTypeName(pt)} {prop.Name}",
-                        disambiguator: TypeNameFormatter.FriendlyFullName(propMatch)));
+                        disambiguator: TypeNameFormatter.FriendlyFullName(propMatch)))) return;
                 }
-
-                if (truncated) break;
 
                 foreach (var field in GetFieldsSafe(candidate, flags))
                 {
-                    if (hits.Count >= cap) { truncated = true; break; }
                     Type? ft;
                     try { ft = field.FieldType; } catch { continue; }
                     var fieldMatch = FindMatchingType(ft, typeName, options.CaseSensitive);
                     if (fieldMatch == null) continue;
-                    hits.Add(MakeRefHit(path, declaringName, "field", field.Name, "field",
+                    if (!TryAdd(MakeRefHit(path, declaringName, "field", field.Name, "field",
                         $"{FriendlyTypeName(ft)} {field.Name}",
-                        disambiguator: TypeNameFormatter.FriendlyFullName(fieldMatch)));
+                        disambiguator: TypeNameFormatter.FriendlyFullName(fieldMatch)))) return;
                 }
-
-                if (truncated) break;
 
                 foreach (var evt in GetEventsSafe(candidate, flags))
                 {
-                    if (hits.Count >= cap) { truncated = true; break; }
                     Type? et;
                     try { et = evt.EventHandlerType; } catch { continue; }
                     var eventMatch = FindMatchingType(et, typeName, options.CaseSensitive);
                     if (eventMatch == null) continue;
-                    hits.Add(MakeRefHit(path, declaringName, "event", evt.Name, "event",
+                    if (!TryAdd(MakeRefHit(path, declaringName, "event", evt.Name, "event",
                         $"event {FriendlyTypeName(et!)} {evt.Name}",
-                        disambiguator: TypeNameFormatter.FriendlyFullName(eventMatch)));
+                        disambiguator: TypeNameFormatter.FriendlyFullName(eventMatch)))) return;
                 }
             }
-            }
-            catch (BadImageFormatException) { }
-            catch (FileLoadException) { }
-            catch (ReflectionTypeLoadException) { }
-            catch (IOException) { }
-        }
+        });
 
         var sorted = hits
             .OrderBy(h => h.AssemblyPath, StringComparer.Ordinal)
@@ -235,7 +214,16 @@ public class ReverseLookupService : IReverseLookupService
             .ThenBy(h => h.DedupeKey, StringComparer.Ordinal)
             .ToArray();
 
-        return new ReferencesResult(sorted, truncated);
+        return new ReferencesResult(sorted, truncated == 1);
+    }
+
+    private void ScanInParallel(string[] assemblyPaths, Action<string, IAssemblyInspectionContext> scan)
+    {
+        var paths = assemblyPaths.Where(File.Exists).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        Parallel.ForEach(
+            paths,
+            new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
+            path => TryScanAssembly(path, scan));
     }
 
     private static ReferenceHit MakeRefHit(
@@ -253,16 +241,17 @@ public class ReverseLookupService : IReverseLookupService
         return new(assemblyPath, declaringType, memberKind, memberName, referenceKind, signature, dedupeKey);
     }
 
-    private static bool TryScanAssembly(string path, Action<IAssemblyInspectionContext> scan)
+    private bool TryScanAssembly(string path, Action<string, IAssemblyInspectionContext> scan)
     {
         try
         {
-            using var ctx = InspectionContextFactory.Create(path);
-            scan(ctx);
+            using var lease = _contexts.Acquire(path);
+            scan(path, lease.Context);
             return true;
         }
         catch (BadImageFormatException) { return false; }
         catch (FileLoadException) { return false; }
+        catch (FileNotFoundException) { return false; }
         catch (ReflectionTypeLoadException) { return false; }
         catch (IOException) { return false; }
     }
@@ -383,44 +372,5 @@ public class ReverseLookupService : IReverseLookupService
         return $"{ret} {m.Name}({ps})";
     }
 
-    private static readonly Dictionary<string, string> FriendlyBuiltIns = new(StringComparer.Ordinal)
-    {
-        ["System.Boolean"] = "bool",
-        ["System.Byte"] = "byte",
-        ["System.SByte"] = "sbyte",
-        ["System.Char"] = "char",
-        ["System.Decimal"] = "decimal",
-        ["System.Double"] = "double",
-        ["System.Single"] = "float",
-        ["System.Int32"] = "int",
-        ["System.UInt32"] = "uint",
-        ["System.Int64"] = "long",
-        ["System.UInt64"] = "ulong",
-        ["System.Object"] = "object",
-        ["System.Int16"] = "short",
-        ["System.UInt16"] = "ushort",
-        ["System.String"] = "string",
-        ["System.Void"] = "void"
-    };
-
-    private static string FriendlyTypeName(Type t)
-    {
-        if (t.IsByRef) return FriendlyTypeName(t.GetElementType()!) + "&";
-        if (t.IsPointer) return FriendlyTypeName(t.GetElementType()!) + "*";
-        if (t.IsArray)
-        {
-            var rank = t.GetArrayRank();
-            var brackets = rank == 1 ? "[]" : "[" + new string(',', rank - 1) + "]";
-            return FriendlyTypeName(t.GetElementType()!) + brackets;
-        }
-        if (t.IsGenericType)
-        {
-            var def = t.GetGenericTypeDefinition().Name;
-            var backtick = def.IndexOf('`');
-            if (backtick > 0) def = def.Substring(0, backtick);
-            var args = string.Join(", ", t.GetGenericArguments().Select(FriendlyTypeName));
-            return $"{def}<{args}>";
-        }
-        return t.FullName is string fn && FriendlyBuiltIns.TryGetValue(fn, out var alias) ? alias : t.Name;
-    }
+    private static string FriendlyTypeName(Type t) => TypeNameFormatter.FriendlyName(t);
 }

--- a/src/runtime/RuntimeOptions.cs
+++ b/src/runtime/RuntimeOptions.cs
@@ -9,6 +9,8 @@ public class RuntimeOptions
         CacheTtlSeconds = 300;
         EnableStreaming = false;
         IncludeNonPublicByDefault = false;
+        MaxLoadedAssemblies = 64;
+        MaxCachedResponses = 256;
 
         ToolSpecificMaxItems = new Dictionary<string, int>
         {
@@ -36,6 +38,10 @@ public class RuntimeOptions
     public bool EnableStreaming { get; set; }
 
     public bool IncludeNonPublicByDefault { get; set; }
+
+    public int MaxLoadedAssemblies { get; set; }
+
+    public int MaxCachedResponses { get; set; }
 
     public Dictionary<string, int> ToolSpecificMaxItems { get; }
 

--- a/src/runtime/TypeAnalysisService.cs
+++ b/src/runtime/TypeAnalysisService.cs
@@ -14,25 +14,32 @@ namespace Sherlock.MCP.Runtime;
 
 public class TypeAnalysisService : ITypeAnalysisService, IDisposable
 {
-    private readonly ConcurrentDictionary<string, IAssemblyInspectionContext> _contexts
+    private readonly IInspectionContextProvider _contexts;
+    private readonly ConcurrentDictionary<string, InspectionContextLease> _pinned
         = new(StringComparer.OrdinalIgnoreCase);
     private bool _disposed;
+
+    public TypeAnalysisService() : this(new SharedInspectionContextProvider(new RuntimeOptions()))
+    {
+    }
+
+    public TypeAnalysisService(IInspectionContextProvider contexts) => _contexts = contexts;
 
     public Assembly? LoadAssembly(string assemblyPath)
     {
         try
         {
             if (!File.Exists(assemblyPath)) return null;
-            if (_contexts.TryGetValue(assemblyPath, out var existing))
+            if (_pinned.TryGetValue(assemblyPath, out var existing))
             {
                 return existing.Assembly;
             }
 
-            var created = InspectionContextFactory.Create(assemblyPath);
-            var stored = _contexts.GetOrAdd(assemblyPath, created);
-            if (!ReferenceEquals(stored, created))
+            var lease = _contexts.Acquire(assemblyPath);
+            var stored = _pinned.GetOrAdd(assemblyPath, lease);
+            if (!ReferenceEquals(stored, lease))
             {
-                created.Dispose();
+                lease.Dispose();
             }
             return stored.Assembly;
         }
@@ -46,11 +53,11 @@ public class TypeAnalysisService : ITypeAnalysisService, IDisposable
     {
         if (_disposed) return;
         _disposed = true;
-        foreach (var ctx in _contexts.Values)
+        foreach (var lease in _pinned.Values)
         {
-            try { ctx.Dispose(); } catch { }
+            try { lease.Dispose(); } catch { }
         }
-        _contexts.Clear();
+        _pinned.Clear();
     }
 
     public TypeAnalysisInfo GetTypeInfo(Type type)
@@ -79,14 +86,57 @@ public class TypeAnalysisService : ITypeAnalysisService, IDisposable
     {
         try
         {
-            using var ctx = InspectionContextFactory.Create(assemblyPath);
-            var type = ctx.Assembly.GetType(typeName);
+            using var lease = _contexts.Acquire(assemblyPath);
+            var type = ResolveType(lease.Context, typeName);
             return type != null ? GetTypeInfo(type) : null;
         }
         catch (Exception)
         {
             return null;
         }
+    }
+
+    public TypeAnalysisHierarchy? GetTypeHierarchy(string assemblyPath, string typeName)
+    {
+        using var lease = _contexts.Acquire(assemblyPath);
+        var type = ResolveType(lease.Context, typeName);
+        return type != null ? GetTypeHierarchy(type) : null;
+    }
+
+    public TypeAnalysisGenericTypeInfo? GetGenericTypeInfo(string assemblyPath, string typeName)
+    {
+        using var lease = _contexts.Acquire(assemblyPath);
+        var type = ResolveType(lease.Context, typeName);
+        return type != null ? GetGenericTypeInfo(type) : null;
+    }
+
+    public (string TypeFullName, TypeAnalysisAttributeInfo[] Attributes)? GetTypeAttributes(string assemblyPath, string typeName)
+    {
+        using var lease = _contexts.Acquire(assemblyPath);
+        var type = ResolveType(lease.Context, typeName);
+        return type != null ? (type.FullName ?? type.Name, GetTypeAttributes(type)) : null;
+    }
+
+    public (string TypeFullName, TypeAnalysisInfo[] NestedTypes)? GetNestedTypes(string assemblyPath, string typeName)
+    {
+        using var lease = _contexts.Acquire(assemblyPath);
+        var type = ResolveType(lease.Context, typeName);
+        return type != null ? (type.FullName ?? type.Name, GetNestedTypes(type)) : null;
+    }
+
+    private static Type? ResolveType(IAssemblyInspectionContext ctx, string typeName)
+    {
+        var type = ctx.Assembly.GetType(typeName);
+        if (type != null) return type;
+
+        var allTypes = ctx.GetTypes().ToArray();
+        type = allTypes.FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
+                                          || string.Equals(t.Name, typeName, StringComparison.Ordinal));
+        if (type != null || !typeName.Contains('.')) return type;
+
+        var nestedCandidate = typeName.Replace('.', '+');
+        return allTypes.FirstOrDefault(t => string.Equals(t.FullName, nestedCandidate, StringComparison.Ordinal))
+            ?? allTypes.FirstOrDefault(t => string.Equals((t.FullName ?? t.Name).Replace('+', '.'), typeName, StringComparison.Ordinal));
     }
 
     public TypeAnalysisHierarchy GetTypeHierarchy(Type type)
@@ -181,8 +231,8 @@ public class TypeAnalysisService : ITypeAnalysisService, IDisposable
     {
         try
         {
-            using var ctx = InspectionContextFactory.Create(assemblyPath);
-            return ctx.Assembly.GetTypes()
+            using var lease = _contexts.Acquire(assemblyPath);
+            return lease.Context.GetTypes()
                 .Where(t => t.IsPublic || t.IsNestedPublic)
                 .Select(GetTypeInfo)
                 .ToArray();

--- a/src/runtime/TypeNameFormatter.cs
+++ b/src/runtime/TypeNameFormatter.cs
@@ -22,4 +22,49 @@ internal static class TypeNameFormatter
         var args = type.GetGenericArguments().Select(FriendlyFullName);
         return $"{stem}<{string.Join(", ", args)}>";
     }
+
+    public static string FriendlyName(System.Type type)
+    {
+        if (type.IsByRef) return FriendlyName(type.GetElementType()!) + "&";
+        if (type.IsPointer) return FriendlyName(type.GetElementType()!) + "*";
+        if (type.IsArray)
+        {
+            var rank = type.GetArrayRank();
+            var brackets = rank == 1 ? "[]" : "[" + new string(',', rank - 1) + "]";
+            return FriendlyName(type.GetElementType()!) + brackets;
+        }
+        if (type.IsGenericType && !type.IsGenericTypeDefinition && type.GetGenericTypeDefinition().FullName == "System.Nullable`1")
+            return FriendlyName(type.GetGenericArguments()[0]) + "?";
+        if (type.IsGenericType)
+        {
+            var stem = type.GetGenericTypeDefinition().Name;
+            var tick = stem.IndexOf('`');
+            if (tick > 0) stem = stem.Substring(0, tick);
+            var args = type.GetGenericArguments().Select(FriendlyName);
+            return $"{stem}<{string.Join(", ", args)}>";
+        }
+        return type.FullName is string fullName && BuiltInTypeNames.TryGetValue(fullName, out var builtInName)
+            ? builtInName
+            : type.Name;
+    }
+
+    private static readonly Dictionary<string, string> BuiltInTypeNames = new(StringComparer.Ordinal)
+    {
+        ["System.Boolean"] = "bool",
+        ["System.Byte"] = "byte",
+        ["System.SByte"] = "sbyte",
+        ["System.Char"] = "char",
+        ["System.Decimal"] = "decimal",
+        ["System.Double"] = "double",
+        ["System.Single"] = "float",
+        ["System.Int32"] = "int",
+        ["System.UInt32"] = "uint",
+        ["System.Int64"] = "long",
+        ["System.UInt64"] = "ulong",
+        ["System.Int16"] = "short",
+        ["System.UInt16"] = "ushort",
+        ["System.Object"] = "object",
+        ["System.String"] = "string",
+        ["System.Void"] = "void"
+    };
 }

--- a/src/runtime/XmlDocService.cs
+++ b/src/runtime/XmlDocService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Xml.Linq;
 using Sherlock.MCP.Runtime.Contracts.XmlDocs;
@@ -6,63 +7,105 @@ namespace Sherlock.MCP.Runtime;
 
 public class XmlDocService : IXmlDocService
 {
-    private readonly Dictionary<string, XDocument?> _xmlCache = new();
+    private const int MaxCachedDocs = 32;
+
+    private sealed record CachedDoc(long StampTicks, long Length, Dictionary<string, XElement> MembersById);
+
+    private readonly ConcurrentDictionary<string, Lazy<CachedDoc?>> _docs = new(StringComparer.OrdinalIgnoreCase);
 
     public XmlDocInfo? GetXmlDocsForType(Type type)
     {
-        var doc = LoadXml(type.Assembly);
+        var doc = LoadDoc(type.Assembly);
         if (doc == null) return null;
         var id = $"T:{type.FullName}";
-        return Extract(doc, id);
+        return doc.MembersById.TryGetValue(id, out var el) ? Extract(el) : null;
     }
 
     public XmlDocInfo? GetXmlDocsForMember(MemberInfo member)
     {
-        var doc = LoadXml(member.Module.Assembly);
+        var doc = LoadDoc(member.Module.Assembly);
         if (doc == null) return null;
         var id = BuildMemberId(member);
-        if (id != null)
-        {
-            var info = Extract(doc, id);
-            if (info != null) return info;
-        }
+        if (id != null && doc.MembersById.TryGetValue(id, out var el))
+            return Extract(el);
+
         // Fallback for methods without signature resolution: first by name
         if (member is MethodBase mb && mb.DeclaringType?.FullName is string fullName)
         {
             var prefix = $"M:{fullName}.{mb.Name}";
-            var e = doc.Descendants("member").FirstOrDefault(x => {
-                var n = (string?)x.Attribute("name");
-                return n != null && n.StartsWith(prefix, StringComparison.Ordinal);
-            });
-            if (e != null) return Extract(e);
+            var match = doc.MembersById
+                .Where(p => p.Key.StartsWith(prefix, StringComparison.Ordinal))
+                .OrderBy(p => p.Key, StringComparer.Ordinal)
+                .Select(p => p.Value)
+                .FirstOrDefault();
+            if (match != null) return Extract(match);
         }
         return null;
     }
 
-    private XDocument? LoadXml(Assembly assembly)
+    private CachedDoc? LoadDoc(Assembly assembly)
     {
         var key = assembly.Location;
         if (string.IsNullOrEmpty(key)) return null;
-        if (_xmlCache.TryGetValue(key, out var cached)) return cached;
+
+        var xmlPath = Path.ChangeExtension(key, ".xml");
+        var fileInfo = new FileInfo(xmlPath);
+        if (!fileInfo.Exists) return null;
+
+        var stampTicks = fileInfo.LastWriteTimeUtc.Ticks;
+        var length = fileInfo.Length;
+
+        while (true)
+        {
+            var lazy = _docs.GetOrAdd(key, _ => new Lazy<CachedDoc?>(
+                () => ParseDoc(xmlPath, stampTicks, length),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+
+            var cached = lazy.Value;
+            if (cached == null)
+            {
+                _docs.TryRemove(new KeyValuePair<string, Lazy<CachedDoc?>>(key, lazy));
+                return null;
+            }
+
+            if (cached.StampTicks != stampTicks || cached.Length != length)
+            {
+                _docs.TryRemove(new KeyValuePair<string, Lazy<CachedDoc?>>(key, lazy));
+                continue;
+            }
+
+            EvictOverflow();
+            return cached;
+        }
+    }
+
+    private static CachedDoc? ParseDoc(string xmlPath, long stampTicks, long length)
+    {
         try
         {
-            var xmlPath = Path.ChangeExtension(key, ".xml");
-            if (!File.Exists(xmlPath)) { _xmlCache[key] = null; return null; }
             var doc = XDocument.Load(xmlPath);
-            _xmlCache[key] = doc;
-            return doc;
+            var membersById = new Dictionary<string, XElement>(StringComparer.Ordinal);
+            foreach (var el in doc.Descendants("member"))
+            {
+                var name = (string?)el.Attribute("name");
+                if (name != null) membersById.TryAdd(name, el);
+            }
+            return new CachedDoc(stampTicks, length, membersById);
         }
         catch
         {
-            _xmlCache[key] = null;
             return null;
         }
     }
 
-    private static XmlDocInfo? Extract(XDocument doc, string memberId)
+    private void EvictOverflow()
     {
-        var el = doc.Descendants("member").FirstOrDefault(x => (string?)x.Attribute("name") == memberId);
-        return el != null ? Extract(el) : (XmlDocInfo?)null;
+        if (_docs.Count <= MaxCachedDocs) return;
+        foreach (var pair in _docs.ToArray())
+        {
+            if (_docs.Count <= MaxCachedDocs) return;
+            _docs.TryRemove(pair);
+        }
     }
 
     private static XmlDocInfo Extract(XElement el)

--- a/src/server/Program.cs
+++ b/src/server/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Sherlock.MCP.Runtime;
 using Sherlock.MCP.Runtime.Caching;
 using Sherlock.MCP.Runtime.Indexing;
+using Sherlock.MCP.Runtime.Inspection;
 using Sherlock.MCP.Runtime.Telemetry;
 using Sherlock.MCP.Server.Middleware;
 using System.Reflection;
@@ -28,6 +29,7 @@ builder.Logging.AddConsole(consoleLogOptions =>
 
 builder.Services
     .AddSingleton<RuntimeOptions>()
+    .AddSingleton<IInspectionContextProvider, SharedInspectionContextProvider>()
     .AddSingleton<IToolResponseCache, InMemoryToolResponseCache>()
     .AddSingleton<IAssemblyIndexService, NoopAssemblyIndexService>()
     .AddSingleton<ITelemetry, NoopTelemetry>()

--- a/src/server/Shared/CacheKeyHelper.cs
+++ b/src/server/Shared/CacheKeyHelper.cs
@@ -13,6 +13,19 @@ public static class CacheKeyHelper
         return $"{baseKey}:{hash}";
     }
 
+    public static string FileStamp(string path)
+    {
+        try
+        {
+            var info = new FileInfo(Path.GetFullPath(path));
+            return info.Exists ? $"{info.FullName}|{info.LastWriteTimeUtc.Ticks}|{info.Length}" : info.FullName;
+        }
+        catch
+        {
+            return path;
+        }
+    }
+
     public static string Sha256(string input)
     {
         using var sha = SHA256.Create();

--- a/src/server/Tools/ConfigTools.cs
+++ b/src/server/Tools/ConfigTools.cs
@@ -18,7 +18,9 @@ public static class ConfigTools
             defaultMaxItems = options.DefaultMaxItems,
             cacheTtlSeconds = options.CacheTtlSeconds,
             enableStreaming = options.EnableStreaming,
-            includeNonPublicByDefault = options.IncludeNonPublicByDefault
+            includeNonPublicByDefault = options.IncludeNonPublicByDefault,
+            maxLoadedAssemblies = options.MaxLoadedAssemblies,
+            maxCachedResponses = options.MaxCachedResponses
         };
 
         return JsonHelpers.Envelope("runtime.options", result);
@@ -33,10 +35,14 @@ public static class ConfigTools
         [Description("Enable server-side streaming")] bool? enableStreaming = null,
         [Description("Include non-public members by default")] bool? includeNonPublicByDefault = null,
         [Description("Add search roots (absolute paths)")] string[]? addSearchRoots = null,
-        [Description("Remove search roots (absolute paths)")] string[]? removeSearchRoots = null)
+        [Description("Remove search roots (absolute paths)")] string[]? removeSearchRoots = null,
+        [Description("Maximum assemblies kept loaded in the inspection cache")] int? maxLoadedAssemblies = null,
+        [Description("Maximum cached tool responses kept in memory")] int? maxCachedResponses = null)
     {
         if (defaultMaxItems is > 0) options.DefaultMaxItems = defaultMaxItems.Value;
         if (cacheTtlSeconds is > 0) options.CacheTtlSeconds = cacheTtlSeconds.Value;
+        if (maxLoadedAssemblies is > 0) options.MaxLoadedAssemblies = maxLoadedAssemblies.Value;
+        if (maxCachedResponses is > 0) options.MaxCachedResponses = maxCachedResponses.Value;
         if (enableStreaming.HasValue) options.EnableStreaming = enableStreaming.Value;
         if (includeNonPublicByDefault.HasValue) options.IncludeNonPublicByDefault = includeNonPublicByDefault.Value;
 

--- a/src/server/Tools/MemberAnalysisTools.cs
+++ b/src/server/Tools/MemberAnalysisTools.cs
@@ -54,14 +54,15 @@ public static class MemberAnalysisTools
             // Salt seed: identifies the result set (filters + ordering). MUST exclude pagination
             // params (continuationToken, skip, take, maxItems) and rendering params (projection)
             // so a token minted on page 1 still validates on page 2.
+            var assemblyStamp = CacheKeyHelper.FileStamp(assemblyPath);
             var saltSeed = CacheKeyHelper.Build(
                 "member.methods.salt",
-                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                assemblyStamp, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
                 caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder);
 
             var cacheKey = CacheKeyHelper.Build(
                 "member.methods",
-                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                assemblyStamp, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
                 caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder, maxItems, continuationToken, skip, take, normalizedProjection);
 
             return middleware.Execute(cacheKey, () =>
@@ -80,19 +81,6 @@ public static class MemberAnalysisTools
                     SortOrder = sortOrder
                 };
 
-                // Resolve type
-                using var ctx = InspectionContextFactory.Create(assemblyPath);
-                var assembly = ctx.Assembly;
-                var type = assembly.GetType(typeName)
-                    ?? assembly.GetExportedTypes()
-                        .FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
-                                           || string.Equals(t.Name, typeName, StringComparison.Ordinal));
-                if (type?.FullName == null)
-                    return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
-
-                // Get full filtered set (no paging yet) to compute total and page safely
-                var all = memberAnalysisService.GetMethods(assemblyPath, type.FullName, options);
-
                 var defaultPageSize = runtimeOptions.GetMaxItemsForTool("GetTypeMethods");
                 var pageSize = Math.Max(1, maxItems ?? take ?? defaultPageSize);
                 var offset = 0;
@@ -109,10 +97,20 @@ public static class MemberAnalysisTools
                     offset = skip.Value;
                 }
 
-                var pageItems = all.Skip(offset).Take(pageSize).ToArray();
+                Sherlock.MCP.Runtime.Contracts.Common.PagedResult<MethodDetails> page;
+                try
+                {
+                    page = memberAnalysisService.GetMethodsPage(assemblyPath, typeName, options, offset, pageSize);
+                }
+                catch (ArgumentException)
+                {
+                    return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
+                }
+
+                var pageItems = page.Items;
                 string? nextToken = null;
                 var nextOffset = offset + pageItems.Length;
-                if (nextOffset < all.Length)
+                if (nextOffset < page.Total)
                 {
                     nextToken = TokenHelper.Make(nextOffset, salt);
                 }
@@ -158,10 +156,10 @@ public static class MemberAnalysisTools
                     typeName,
                     assemblyPath,
                     projection = normalizedProjection,
-                    total = all.Length,
+                    total = page.Total,
                     count = pageItems.Length,
                     nextToken,
-                    pagination = PaginationMetadata.Create(all.Length, pageItems.Length, nextToken, methodsJson.Length),
+                    pagination = PaginationMetadata.Create(page.Total, pageItems.Length, nextToken, methodsJson.Length),
                     methods
                 };
 
@@ -179,6 +177,7 @@ public static class MemberAnalysisTools
     [McpServerTool]
     [Description("Gets custom attributes for a specific member (method, property, field, event, constructor). Returns attribute types and values. Use after identifying the member via GetTypeMethods or similar tools.")]
     public static string GetMemberAttributes(
+        IInspectionContextProvider contexts,
         [Description("Path to the .NET assembly file (.dll or .exe)")] string assemblyPath,
         [Description("Type name. Prefer full name")]
         string typeName,
@@ -190,8 +189,8 @@ public static class MemberAnalysisTools
         {
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
-            using var ctx = InspectionContextFactory.Create(assemblyPath);
-            var asm = ctx.Assembly;
+            using var lease = contexts.Acquire(assemblyPath);
+            var asm = lease.Assembly;
             var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
             var type = asm.GetType(typeName)
                        ?? asm.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, comparison) || string.Equals(t.Name, typeName, comparison));
@@ -223,6 +222,7 @@ public static class MemberAnalysisTools
     [McpServerTool]
     [Description("Gets custom attributes for a specific parameter of a method or constructor. Use when you need to inspect parameter-level attributes like [FromBody], [Required], etc.")]
     public static string GetParameterAttributes(
+        IInspectionContextProvider contexts,
         [Description("Path to the .NET assembly file (.dll or .exe)")] string assemblyPath,
         [Description("Type name. Prefer full name")] string typeName,
         [Description("Method or constructor name")] string methodName,
@@ -233,8 +233,8 @@ public static class MemberAnalysisTools
         {
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
-            using var ctx = InspectionContextFactory.Create(assemblyPath);
-            var asm = ctx.Assembly;
+            using var lease = contexts.Acquire(assemblyPath);
+            var asm = lease.Assembly;
             var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
             var type = asm.GetType(typeName)
                        ?? asm.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, comparison) || string.Equals(t.Name, typeName, comparison));
@@ -290,14 +290,15 @@ public static class MemberAnalysisTools
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
+            var assemblyStamp = CacheKeyHelper.FileStamp(assemblyPath);
             var saltSeed = CacheKeyHelper.Build(
                 "member.properties.salt",
-                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                assemblyStamp, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
                 caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder);
 
             var cacheKey = CacheKeyHelper.Build(
                 "member.properties",
-                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                assemblyStamp, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
                 caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder, maxItems, continuationToken, skip, take);
 
             return middleware.Execute(cacheKey, () =>
@@ -316,19 +317,6 @@ public static class MemberAnalysisTools
                     SortOrder = sortOrder
                 };
 
-                // Resolve type
-                using var ctx = InspectionContextFactory.Create(assemblyPath);
-                var assembly = ctx.Assembly;
-                var type = assembly.GetType(typeName)
-                    ?? assembly.GetExportedTypes()
-                        .FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
-                                           || string.Equals(t.Name, typeName, StringComparison.Ordinal));
-                if (type?.FullName == null)
-                    return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
-
-                // Get full filtered set (no paging yet) to compute total and page safely
-                var all = memberAnalysisService.GetProperties(assemblyPath, type.FullName, options);
-
                 var defaultPageSize = runtimeOptions.GetMaxItemsForTool("GetTypeProperties");
                 var pageSize = Math.Max(1, maxItems ?? take ?? defaultPageSize);
                 var offset = 0;
@@ -345,10 +333,20 @@ public static class MemberAnalysisTools
                     offset = skip.Value;
                 }
 
-                var pageItems = all.Skip(offset).Take(pageSize).ToArray();
+                Sherlock.MCP.Runtime.Contracts.Common.PagedResult<PropertyDetails> page;
+                try
+                {
+                    page = memberAnalysisService.GetPropertiesPage(assemblyPath, typeName, options, offset, pageSize);
+                }
+                catch (ArgumentException)
+                {
+                    return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
+                }
+
+                var pageItems = page.Items;
                 string? nextToken = null;
                 var nextOffset = offset + pageItems.Length;
-                if (nextOffset < all.Length)
+                if (nextOffset < page.Total)
                 {
                     nextToken = TokenHelper.Make(nextOffset, salt);
                 }
@@ -357,7 +355,7 @@ public static class MemberAnalysisTools
                 {
                     typeName,
                     assemblyPath,
-                    total = all.Length,
+                    total = page.Total,
                     count = pageItems.Length,
                     nextToken,
                     properties = pageItems.Select(p => new
@@ -425,14 +423,15 @@ public static class MemberAnalysisTools
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
+            var assemblyStamp = CacheKeyHelper.FileStamp(assemblyPath);
             var saltSeed = CacheKeyHelper.Build(
                 "member.fields.salt",
-                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                assemblyStamp, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
                 caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder);
 
             var cacheKey = CacheKeyHelper.Build(
                 "member.fields",
-                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                assemblyStamp, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
                 caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder, maxItems, continuationToken, skip, take);
 
             return middleware.Execute(cacheKey, () =>
@@ -451,19 +450,6 @@ public static class MemberAnalysisTools
                     SortOrder = sortOrder
                 };
 
-                // Resolve type
-                using var ctx = InspectionContextFactory.Create(assemblyPath);
-                var assembly = ctx.Assembly;
-                var type = assembly.GetType(typeName)
-                    ?? assembly.GetExportedTypes()
-                        .FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
-                                           || string.Equals(t.Name, typeName, StringComparison.Ordinal));
-                if (type?.FullName == null)
-                    return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
-
-                // Get full filtered set (no paging yet) to compute total and page safely
-                var all = memberAnalysisService.GetFields(assemblyPath, type.FullName, options);
-
                 var defaultPageSize = runtimeOptions.GetMaxItemsForTool("GetTypeFields");
                 var pageSize = Math.Max(1, maxItems ?? take ?? defaultPageSize);
                 var offset = 0;
@@ -480,10 +466,20 @@ public static class MemberAnalysisTools
                     offset = skip.Value;
                 }
 
-                var pageItems = all.Skip(offset).Take(pageSize).ToArray();
+                Sherlock.MCP.Runtime.Contracts.Common.PagedResult<FieldDetails> page;
+                try
+                {
+                    page = memberAnalysisService.GetFieldsPage(assemblyPath, typeName, options, offset, pageSize);
+                }
+                catch (ArgumentException)
+                {
+                    return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
+                }
+
+                var pageItems = page.Items;
                 string? nextToken = null;
                 var nextOffset = offset + pageItems.Length;
-                if (nextOffset < all.Length)
+                if (nextOffset < page.Total)
                 {
                     nextToken = TokenHelper.Make(nextOffset, salt);
                 }
@@ -492,7 +488,7 @@ public static class MemberAnalysisTools
                 {
                     typeName,
                     assemblyPath,
-                    total = all.Length,
+                    total = page.Total,
                     count = pageItems.Length,
                     nextToken,
                     fields = pageItems.Select(f => new
@@ -547,14 +543,15 @@ public static class MemberAnalysisTools
         {
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
+            var assemblyStamp = CacheKeyHelper.FileStamp(assemblyPath);
             var saltSeed = CacheKeyHelper.Build(
                 "member.events.salt",
-                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                assemblyStamp, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
                 caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder);
 
             var cacheKey = CacheKeyHelper.Build(
                 "member.events",
-                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                assemblyStamp, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
                 caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder, maxItems, continuationToken, skip, take);
 
             return middleware.Execute(cacheKey, () =>
@@ -572,17 +569,6 @@ public static class MemberAnalysisTools
                     SortOrder = sortOrder
                 };
 
-                using var ctx = InspectionContextFactory.Create(assemblyPath);
-                var assembly = ctx.Assembly;
-                var type = assembly.GetType(typeName)
-                    ?? assembly.GetExportedTypes()
-                        .FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
-                                           || string.Equals(t.Name, typeName, StringComparison.Ordinal));
-                if (type?.FullName == null)
-                    return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
-
-                var all = memberAnalysisService.GetEvents(assemblyPath, type.FullName, options);
-
                 var defaultPageSize = runtimeOptions.GetMaxItemsForTool("GetTypeEvents");
                 var pageSize = Math.Max(1, maxItems ?? take ?? defaultPageSize);
                 var offset = 0;
@@ -599,10 +585,20 @@ public static class MemberAnalysisTools
                     offset = skip.Value;
                 }
 
-                var pageItems = all.Skip(offset).Take(pageSize).ToArray();
+                Sherlock.MCP.Runtime.Contracts.Common.PagedResult<EventDetails> page;
+                try
+                {
+                    page = memberAnalysisService.GetEventsPage(assemblyPath, typeName, options, offset, pageSize);
+                }
+                catch (ArgumentException)
+                {
+                    return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
+                }
+
+                var pageItems = page.Items;
                 string? nextToken = null;
                 var nextOffset = offset + pageItems.Length;
-                if (nextOffset < all.Length)
+                if (nextOffset < page.Total)
                 {
                     nextToken = TokenHelper.Make(nextOffset, salt);
                 }
@@ -611,7 +607,7 @@ public static class MemberAnalysisTools
                 {
                     typeName,
                     assemblyPath,
-                    total = all.Length,
+                    total = page.Total,
                     count = pageItems.Length,
                     nextToken,
                     events = pageItems.Select(e => new
@@ -668,14 +664,15 @@ public static class MemberAnalysisTools
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
+            var assemblyStamp = CacheKeyHelper.FileStamp(assemblyPath);
             var saltSeed = CacheKeyHelper.Build(
                 "member.constructors.salt",
-                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                assemblyStamp, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
                 caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder);
 
             var cacheKey = CacheKeyHelper.Build(
                 "member.constructors",
-                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
+                assemblyStamp, typeName, includePublic, includeNonPublic, includeStatic, includeInstance,
                 caseSensitive, nameContains, hasAttributeContains, sortBy, sortOrder, maxItems, continuationToken, skip, take);
 
             return middleware.Execute(cacheKey, () =>
@@ -693,17 +690,6 @@ public static class MemberAnalysisTools
                     SortOrder = sortOrder
                 };
 
-                using var ctx = InspectionContextFactory.Create(assemblyPath);
-                var assembly = ctx.Assembly;
-                var type = assembly.GetType(typeName)
-                    ?? assembly.GetExportedTypes()
-                        .FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
-                                           || string.Equals(t.Name, typeName, StringComparison.Ordinal));
-                if (type?.FullName == null)
-                    return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
-
-                var all = memberAnalysisService.GetConstructors(assemblyPath, type.FullName, options);
-
                 var defaultPageSize = runtimeOptions.GetMaxItemsForTool("GetTypeConstructors");
                 var pageSize = Math.Max(1, maxItems ?? take ?? defaultPageSize);
                 var offset = 0;
@@ -720,10 +706,20 @@ public static class MemberAnalysisTools
                     offset = skip.Value;
                 }
 
-                var pageItems = all.Skip(offset).Take(pageSize).ToArray();
+                Sherlock.MCP.Runtime.Contracts.Common.PagedResult<ConstructorDetails> page;
+                try
+                {
+                    page = memberAnalysisService.GetConstructorsPage(assemblyPath, typeName, options, offset, pageSize);
+                }
+                catch (ArgumentException)
+                {
+                    return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
+                }
+
+                var pageItems = page.Items;
                 string? nextToken = null;
                 var nextOffset = offset + pageItems.Length;
-                if (nextOffset < all.Length)
+                if (nextOffset < page.Total)
                 {
                     nextToken = TokenHelper.Make(nextOffset, salt);
                 }
@@ -732,7 +728,7 @@ public static class MemberAnalysisTools
                 {
                     typeName,
                     assemblyPath,
-                    total = all.Length,
+                    total = page.Total,
                     count = pageItems.Length,
                     nextToken,
                     constructors = pageItems.Select(c => new
@@ -783,7 +779,7 @@ public static class MemberAnalysisTools
 
             var cacheKey = CacheKeyHelper.Build(
                 "member.all",
-                assemblyPath, typeName, includePublic, includeNonPublic, includeStatic, includeInstance);
+                CacheKeyHelper.FileStamp(assemblyPath), typeName, includePublic, includeNonPublic, includeStatic, includeInstance);
 
             return middleware.Execute(cacheKey, () =>
             {
@@ -795,20 +791,23 @@ public static class MemberAnalysisTools
                     IncludeInstance = includeInstance
                 };
 
-                using var ctx = InspectionContextFactory.Create(assemblyPath);
-                var assembly = ctx.Assembly;
-                var type = assembly.GetType(typeName)
-                    ?? assembly.GetExportedTypes()
-                        .FirstOrDefault(t => string.Equals(t.FullName, typeName, StringComparison.Ordinal)
-                                           || string.Equals(t.Name, typeName, StringComparison.Ordinal));
-                if (type?.FullName == null)
+                MethodDetails[] methods;
+                PropertyDetails[] properties;
+                FieldDetails[] fields;
+                EventDetails[] events;
+                ConstructorDetails[] constructors;
+                try
+                {
+                    methods = memberAnalysisService.GetMethods(assemblyPath, typeName, options);
+                    properties = memberAnalysisService.GetProperties(assemblyPath, typeName, options);
+                    fields = memberAnalysisService.GetFields(assemblyPath, typeName, options);
+                    events = memberAnalysisService.GetEvents(assemblyPath, typeName, options);
+                    constructors = memberAnalysisService.GetConstructors(assemblyPath, typeName, options);
+                }
+                catch (ArgumentException)
+                {
                     return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
-
-                var methods = memberAnalysisService.GetMethods(assemblyPath, type.FullName, options);
-                var properties = memberAnalysisService.GetProperties(assemblyPath, type.FullName, options);
-                var fields = memberAnalysisService.GetFields(assemblyPath, type.FullName, options);
-                var events = memberAnalysisService.GetEvents(assemblyPath, type.FullName, options);
-                var constructors = memberAnalysisService.GetConstructors(assemblyPath, type.FullName, options);
+                }
 
                 var result = new
                 {

--- a/src/server/Tools/ReflectionTools.cs
+++ b/src/server/Tools/ReflectionTools.cs
@@ -17,6 +17,7 @@ public static class ReflectionTools
     [McpServerTool]
     [Description("Lists all public types in an assembly with metadata summary. Returns totalTypeCount for pagination planning. Use maxItems=25 for large assemblies (100+ types). Follow with GetTypeInfo for specific types.")]
     public static string AnalyzeAssembly(
+        IInspectionContextProvider contexts,
         RuntimeOptions runtimeOptions,
         [Description("Path to the .NET assembly file (.dll or .exe)")] string assemblyPath,
         [Description("Maximum number of types to return (default: 50)")] int? maxItems = null,
@@ -28,8 +29,8 @@ public static class ReflectionTools
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
-            using var ctx = InspectionContextFactory.Create(assemblyPath);
-            var assembly = ctx.Assembly;
+            using var lease = contexts.Acquire(assemblyPath);
+            var assembly = lease.Assembly;
             Type[] allTypes;
             try
             {
@@ -45,7 +46,7 @@ public static class ReflectionTools
             var pageSize = Math.Max(1, maxItems ?? defaultPageSize);
             var offset = 0;
 
-            var cacheKey = $"analyze_assembly_{assemblyPath}_{pageSize}";
+            var cacheKey = $"analyze_assembly_{CacheKeyHelper.FileStamp(assemblyPath)}_{pageSize}";
             var salt = TokenHelper.MakeSalt(cacheKey);
 
             if (!string.IsNullOrWhiteSpace(continuationToken))
@@ -202,6 +203,7 @@ public static class ReflectionTools
     [McpServerTool]
     [Description("Gets type metadata with paginated members (constructors, methods, properties, fields). Returns member totals for pagination planning. Use include* flags to filter member categories. Consider GetTypeMethods etc. for targeted queries.")]
     public static string AnalyzeType(
+        IInspectionContextProvider contexts,
         [Description("Path to the .NET assembly file (.dll or .exe)")] string assemblyPath,
         [Description("Type name to analyze. Prefer full name (e.g., 'System.String'); simple names are also accepted")] string typeName,
         [Description("Maximum number of members to return per category (default: 25)")] int? maxItems = null,
@@ -217,8 +219,8 @@ public static class ReflectionTools
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
-            using var ctx = InspectionContextFactory.Create(assemblyPath);
-            var assembly = ctx.Assembly;
+            using var lease = contexts.Acquire(assemblyPath);
+            var assembly = lease.Assembly;
             Type[] exportedTypes;
             try
             {
@@ -240,7 +242,7 @@ public static class ReflectionTools
             var pageSize = Math.Max(1, maxItems ?? defaultPageSize);
             var offset = 0;
 
-            var cacheKey = $"analyze_type_{assemblyPath}_{typeName}_{pageSize}";
+            var cacheKey = $"analyze_type_{CacheKeyHelper.FileStamp(assemblyPath)}_{typeName}_{pageSize}";
             var salt = TokenHelper.MakeSalt(cacheKey);
 
             if (!string.IsNullOrWhiteSpace(continuationToken))
@@ -458,6 +460,7 @@ public static class ReflectionTools
     [McpServerTool]
     [Description("Gets detailed info about a specific method including all overloads, parameters, attributes, and return types. Use after finding method via GetTypeMethods. Lightweight response.")]
     public static string AnalyzeMethod(
+        IInspectionContextProvider contexts,
         [Description("Path to the .NET assembly file (.dll or .exe)")] string assemblyPath,
         [Description("Type name containing the method. Prefer full name (e.g., 'System.String'); simple names are also accepted")] string typeName,
         [Description("Name of the method to analyze")] string methodName)
@@ -467,8 +470,8 @@ public static class ReflectionTools
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
-            using var ctx = InspectionContextFactory.Create(assemblyPath);
-            var assembly = ctx.Assembly;
+            using var lease = contexts.Acquire(assemblyPath);
+            var assembly = lease.Assembly;
             Type[] exportedTypes;
             try
             {

--- a/src/server/Tools/ReverseLookupTools.cs
+++ b/src/server/Tools/ReverseLookupTools.cs
@@ -39,7 +39,7 @@ public static class ReverseLookupTools
             if (normalizedProjection != "summary" && normalizedProjection != "full")
                 return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
 
-            var scopeKey = string.Join(";", scope.Paths);
+            var scopeKey = string.Join(";", scope.Paths.Select(CacheKeyHelper.FileStamp));
             var saltSeed = CacheKeyHelper.Build(
                 "reverselookup.implementations.salt",
                 scopeKey, typeName, caseSensitive, includeNonPublic);
@@ -131,7 +131,7 @@ public static class ReverseLookupTools
             if (normalizedProjection != "summary" && normalizedProjection != "full")
                 return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
 
-            var scopeKey = string.Join(";", scope.Paths);
+            var scopeKey = string.Join(";", scope.Paths.Select(CacheKeyHelper.FileStamp));
             var saltSeed = CacheKeyHelper.Build(
                 "reverselookup.returning.salt",
                 scopeKey, typeName, caseSensitive, includeNonPublic);
@@ -229,7 +229,7 @@ public static class ReverseLookupTools
             if (normalizedProjection != "summary" && normalizedProjection != "full")
                 return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
 
-            var scopeKey = string.Join(";", scope.Paths);
+            var scopeKey = string.Join(";", scope.Paths.Select(CacheKeyHelper.FileStamp));
             var saltSeed = CacheKeyHelper.Build(
                 "reverselookup.references.salt",
                 scopeKey, typeName, caseSensitive, includeNonPublic);

--- a/src/server/Tools/TypeAnalysisTools.cs
+++ b/src/server/Tools/TypeAnalysisTools.cs
@@ -38,7 +38,7 @@ public static class TypeAnalysisTools
             var pageSize = Math.Max(1, maxItems ?? defaultPageSize);
             var offset = 0;
 
-            var cacheKey = $"types_from_assembly_{assemblyPath}_{pageSize}";
+            var cacheKey = $"types_from_assembly_{CacheKeyHelper.FileStamp(assemblyPath)}_{pageSize}";
             var salt = TokenHelper.MakeSalt(cacheKey);
 
             if (!string.IsNullOrWhiteSpace(continuationToken))
@@ -92,16 +92,6 @@ public static class TypeAnalysisTools
 
             var info = typeAnalysis.GetTypeInfo(assemblyPath, typeName);
             if (info == null)
-            {
-                // Fallback to simple-name lookup
-                var asm = typeAnalysis.LoadAssembly(assemblyPath);
-                var type = asm?.GetTypes().FirstOrDefault(t => t.Name == typeName);
-                if (type != null)
-                {
-                    info = typeAnalysis.GetTypeInfo(type);
-                }
-            }
-            if (info == null)
                 return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
 
             return JsonHelpers.Envelope("type.info", info);
@@ -122,11 +112,9 @@ public static class TypeAnalysisTools
     {
         try
         {
-            var asm = typeAnalysis.LoadAssembly(assemblyPath);
-            if (asm == null) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
-            var type = asm.GetType(typeName) ?? asm.GetTypes().FirstOrDefault(t => t.Name == typeName);
-            if (type == null) return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
-            var hierarchy = typeAnalysis.GetTypeHierarchy(type);
+            if (!File.Exists(assemblyPath)) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
+            var hierarchy = typeAnalysis.GetTypeHierarchy(assemblyPath, typeName);
+            if (hierarchy == null) return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
             return JsonHelpers.Envelope("type.hierarchy", hierarchy);
         }
         catch (Exception ex)
@@ -145,11 +133,9 @@ public static class TypeAnalysisTools
     {
         try
         {
-            var asm = typeAnalysis.LoadAssembly(assemblyPath);
-            if (asm == null) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
-            var type = asm.GetType(typeName) ?? asm.GetTypes().FirstOrDefault(t => t.Name == typeName);
-            if (type == null) return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
-            var genericInfo = typeAnalysis.GetGenericTypeInfo(type);
+            if (!File.Exists(assemblyPath)) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
+            var genericInfo = typeAnalysis.GetGenericTypeInfo(assemblyPath, typeName);
+            if (genericInfo == null) return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
             return JsonHelpers.Envelope("type.generic", genericInfo);
         }
         catch (Exception ex)
@@ -168,12 +154,11 @@ public static class TypeAnalysisTools
     {
         try
         {
-            var asm = typeAnalysis.LoadAssembly(assemblyPath);
-            if (asm == null) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
-            var type = asm.GetType(typeName) ?? asm.GetTypes().FirstOrDefault(t => t.Name == typeName);
-            if (type == null) return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
-            var attributes = typeAnalysis.GetTypeAttributes(type);
-            return JsonHelpers.Envelope("type.attributes", new { typeName = type.FullName, attributeCount = attributes.Length, attributes });
+            if (!File.Exists(assemblyPath)) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
+            var lookup = typeAnalysis.GetTypeAttributes(assemblyPath, typeName);
+            if (lookup == null) return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
+            var (typeFullName, attributes) = lookup.Value;
+            return JsonHelpers.Envelope("type.attributes", new { typeName = typeFullName, attributeCount = attributes.Length, attributes });
         }
         catch (Exception ex)
         {
@@ -191,12 +176,11 @@ public static class TypeAnalysisTools
     {
         try
         {
-            var asm = typeAnalysis.LoadAssembly(assemblyPath);
-            if (asm == null) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
-            var type = asm.GetType(typeName) ?? asm.GetTypes().FirstOrDefault(t => t.Name == typeName);
-            if (type == null) return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
-            var nested = typeAnalysis.GetNestedTypes(type);
-            return JsonHelpers.Envelope("type.nested", new { typeName = type.FullName, nestedTypeCount = nested.Length, nested });
+            if (!File.Exists(assemblyPath)) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
+            var lookup = typeAnalysis.GetNestedTypes(assemblyPath, typeName);
+            if (lookup == null) return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
+            var (typeFullName, nested) = lookup.Value;
+            return JsonHelpers.Envelope("type.nested", new { typeName = typeFullName, nestedTypeCount = nested.Length, nested });
         }
         catch (Exception ex)
         {

--- a/src/server/Tools/XmlDocTools.cs
+++ b/src/server/Tools/XmlDocTools.cs
@@ -14,6 +14,7 @@ public static class XmlDocTools
     [Description("Gets XML documentation (summary, remarks, examples) for a type from adjacent .xml file. Requires XML docs to be generated during build. Lightweight response.")]
     public static string GetXmlDocsForType(
         IXmlDocService xmlDocs,
+        IInspectionContextProvider contexts,
         [Description("Path to the .NET assembly file (.dll or .exe)")] string assemblyPath,
         [Description("Type name. Prefer full name")] string typeName,
         [Description("Case sensitive matching (default: false)")] bool caseSensitive = false)
@@ -21,8 +22,8 @@ public static class XmlDocTools
         try
         {
             if (!File.Exists(assemblyPath)) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
-            using var ctx = InspectionContextFactory.Create(assemblyPath);
-            var asm = ctx.Assembly;
+            using var lease = contexts.Acquire(assemblyPath);
+            var asm = lease.Assembly;
             var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
             var type = asm.GetType(typeName)
                     ?? asm.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, comparison) || string.Equals(t.Name, typeName, comparison));
@@ -42,6 +43,7 @@ public static class XmlDocTools
     [Description("Gets XML documentation (summary, params, returns, exceptions) for a member from adjacent .xml file. Requires XML docs to be generated during build. Lightweight response.")]
     public static string GetXmlDocsForMember(
         IXmlDocService xmlDocs,
+        IInspectionContextProvider contexts,
         [Description("Path to the .NET assembly file (.dll or .exe)")] string assemblyPath,
         [Description("Type name. Prefer full name")] string typeName,
         [Description("Member name (simple; if overloaded, first match used)")] string memberName,
@@ -50,8 +52,8 @@ public static class XmlDocTools
         try
         {
             if (!File.Exists(assemblyPath)) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
-            using var ctx = InspectionContextFactory.Create(assemblyPath);
-            var asm = ctx.Assembly;
+            using var lease = contexts.Acquire(assemblyPath);
+            var asm = lease.Assembly;
             var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
             var type = asm.GetType(typeName)
                     ?? asm.GetTypes().FirstOrDefault(t => string.Equals(t.FullName, typeName, comparison) || string.Equals(t.Name, typeName, comparison));

--- a/src/unit-tests/PaginationTests.cs
+++ b/src/unit-tests/PaginationTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Sherlock.MCP.Runtime;
 using Sherlock.MCP.Runtime.Caching;
+using Sherlock.MCP.Runtime.Inspection;
 using Sherlock.MCP.Runtime.Telemetry;
 using Sherlock.MCP.Server.Tools;
 using Sherlock.MCP.Server.Middleware;
@@ -13,6 +14,7 @@ public class PaginationTests
     private readonly ITypeAnalysisService _typeAnalysisService = new TypeAnalysisService();
     private readonly IMemberAnalysisService _memberAnalysisService = new MemberAnalysisService();
     private readonly RuntimeOptions _runtimeOptions = new RuntimeOptions();
+    private readonly IInspectionContextProvider _contexts;
     private readonly ToolMiddleware _middleware;
     private readonly string _testAssemblyPath;
 
@@ -21,6 +23,7 @@ public class PaginationTests
         var cache = new InMemoryToolResponseCache();
         var telemetry = new NoopTelemetry();
         _middleware = new ToolMiddleware(cache, telemetry, _runtimeOptions);
+        _contexts = new SharedInspectionContextProvider(_runtimeOptions);
         _testAssemblyPath = Assembly.GetExecutingAssembly().Location;
     }
 
@@ -28,7 +31,7 @@ public class PaginationTests
     public void AnalyzeAssembly_WithPagination_ReturnsCorrectPageSize()
     {
         // Act
-        var result = ReflectionTools.AnalyzeAssembly(_runtimeOptions, _testAssemblyPath, maxItems: 5);
+        var result = ReflectionTools.AnalyzeAssembly(_contexts, _runtimeOptions, _testAssemblyPath, maxItems: 5);
 
         // Assert
         Assert.NotNull(result);
@@ -108,7 +111,7 @@ public class PaginationTests
     public void ContinuationToken_WithInvalidToken_ReturnsError()
     {
         // Act
-        var result = ReflectionTools.AnalyzeAssembly(_runtimeOptions, _testAssemblyPath, maxItems: 5, continuationToken: "invalid-token");
+        var result = ReflectionTools.AnalyzeAssembly(_contexts, _runtimeOptions, _testAssemblyPath, maxItems: 5, continuationToken: "invalid-token");
 
         // Assert
         Assert.NotNull(result);
@@ -294,7 +297,7 @@ public class PaginationTests
         try
         {
             // Act - don't specify maxItems to test default
-            var result = ReflectionTools.AnalyzeAssembly(_runtimeOptions, _testAssemblyPath);
+            var result = ReflectionTools.AnalyzeAssembly(_contexts, _runtimeOptions, _testAssemblyPath);
 
             // Assert
             Assert.NotNull(result);

--- a/src/unit-tests/PhaseAImprovementTests.cs
+++ b/src/unit-tests/PhaseAImprovementTests.cs
@@ -1,0 +1,184 @@
+using System.Reflection;
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Caching;
+using Sherlock.MCP.Runtime.Contracts.MemberAnalysis;
+using Sherlock.MCP.Runtime.Inspection;
+using Sherlock.MCP.Server.Shared;
+
+namespace Sherlock.MCP.Tests;
+
+public class PhaseAImprovementTests
+{
+    private readonly string _testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+    [Fact]
+    public void XmlDocService_Is_ThreadSafe_Under_Concurrent_Access()
+    {
+        var xmlService = new XmlDocService();
+        var testType = typeof(TestSampleClass);
+        var method = testType.GetMethod("MethodWithParameters")!;
+
+        Parallel.For(0, 64, _ =>
+        {
+            var typeDocs = xmlService.GetXmlDocsForType(testType);
+            Assert.NotNull(typeDocs);
+            var methodDocs = xmlService.GetXmlDocsForMember(method);
+            Assert.NotNull(methodDocs);
+        });
+    }
+
+    [Fact]
+    public void FileStamp_Changes_When_File_Is_Rewritten()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sherlock-stamp-{Guid.NewGuid():N}.tmp");
+        try
+        {
+            File.WriteAllText(path, "one");
+            var first = CacheKeyHelper.FileStamp(path);
+            File.WriteAllText(path, "two-longer");
+            var second = CacheKeyHelper.FileStamp(path);
+            Assert.NotEqual(first, second);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void FileStamp_Is_Stable_For_Unchanged_File()
+    {
+        var first = CacheKeyHelper.FileStamp(_testAssemblyPath);
+        var second = CacheKeyHelper.FileStamp(_testAssemblyPath);
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void ToolResponseCache_Stays_Bounded_And_Keeps_Recent_Entries()
+    {
+        var options = new RuntimeOptions { MaxCachedResponses = 16 };
+        var cache = new InMemoryToolResponseCache(options);
+
+        for (var i = 0; i < 100; i++)
+            cache.Set($"key-{i}", $"payload-{i}", TimeSpan.FromMinutes(5 + i));
+
+        var retrievable = Enumerable.Range(0, 100).Count(i => cache.TryGet($"key-{i}", out _));
+        Assert.InRange(retrievable, 1, 17);
+        Assert.True(cache.TryGet("key-99", out var newest));
+        Assert.Equal("payload-99", newest);
+    }
+
+    [Fact]
+    public void ContextProvider_Returns_Fresh_Metadata_After_File_Change()
+    {
+        var provider = new SharedInspectionContextProvider(new RuntimeOptions());
+        var tempPath = Path.Combine(Path.GetTempPath(), $"sherlock-fresh-{Guid.NewGuid():N}.dll");
+        var otherAssemblyPath = typeof(RuntimeOptions).Assembly.Location;
+        try
+        {
+            File.Copy(_testAssemblyPath, tempPath);
+            string? firstName;
+            using (var lease = provider.Acquire(tempPath))
+                firstName = lease.Assembly.GetName().Name;
+
+            File.Delete(tempPath);
+            File.Copy(otherAssemblyPath, tempPath);
+            File.SetLastWriteTimeUtc(tempPath, DateTime.UtcNow.AddSeconds(5));
+            string? secondName;
+            using (var lease = provider.Acquire(tempPath))
+                secondName = lease.Assembly.GetName().Name;
+
+            Assert.NotEqual(firstName, secondName);
+            Assert.Equal(typeof(RuntimeOptions).Assembly.GetName().Name, secondName);
+        }
+        finally
+        {
+            provider.Dispose();
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public void ContextProvider_Reuses_Context_For_Unchanged_File()
+    {
+        var provider = new SharedInspectionContextProvider(new RuntimeOptions());
+        try
+        {
+            Assembly first;
+            Assembly second;
+            using (var lease = provider.Acquire(_testAssemblyPath))
+                first = lease.Assembly;
+            using (var lease = provider.Acquire(_testAssemblyPath))
+                second = lease.Assembly;
+            Assert.Same(first, second);
+        }
+        finally
+        {
+            provider.Dispose();
+        }
+    }
+
+    [Fact]
+    public void ContextProvider_Handles_Concurrent_Acquire()
+    {
+        var provider = new SharedInspectionContextProvider(new RuntimeOptions { MaxLoadedAssemblies = 2 });
+        var paths = new[]
+        {
+            _testAssemblyPath,
+            typeof(RuntimeOptions).Assembly.Location,
+            typeof(Sherlock.MCP.Server.Shared.CacheKeyHelper).Assembly.Location
+        };
+        try
+        {
+            Parallel.For(0, 32, i =>
+            {
+                using var lease = provider.Acquire(paths[i % paths.Length]);
+                Assert.NotNull(lease.Assembly.FullName);
+            });
+        }
+        finally
+        {
+            provider.Dispose();
+        }
+    }
+
+    [Fact]
+    public void GetMethodsPage_Matches_Unpaged_Results()
+    {
+        var service = new MemberAnalysisService();
+        var options = new MemberFilterOptions();
+        var all = service.GetMethods(_testAssemblyPath, "Sherlock.MCP.Tests.TestSampleClass", options);
+        var page = service.GetMethodsPage(_testAssemblyPath, "Sherlock.MCP.Tests.TestSampleClass", new MemberFilterOptions(), offset: 0, pageSize: int.MaxValue);
+
+        Assert.Equal(all.Length, page.Total);
+        Assert.Equal(all.Select(m => m.Signature), page.Items.Select(m => m.Signature));
+    }
+
+    [Fact]
+    public void GetMethodsPage_Total_Is_Stable_Across_Pages()
+    {
+        var service = new MemberAnalysisService();
+        var first = service.GetMethodsPage(_testAssemblyPath, "Sherlock.MCP.Tests.TestSampleClass", new MemberFilterOptions(), offset: 0, pageSize: 2);
+        var second = service.GetMethodsPage(_testAssemblyPath, "Sherlock.MCP.Tests.TestSampleClass", new MemberFilterOptions(), offset: 2, pageSize: 2);
+
+        Assert.Equal(first.Total, second.Total);
+        Assert.Equal(2, first.Items.Length);
+        Assert.Empty(first.Items.Select(m => m.Signature).Intersect(second.Items.Select(m => m.Signature)));
+    }
+
+    [Fact]
+    public void Members_Sort_By_Access_Is_Supported()
+    {
+        var service = new MemberAnalysisService();
+        var options = new MemberFilterOptions
+        {
+            IncludeNonPublic = true,
+            SortBy = "access"
+        };
+        var methods = service.GetMethods(_testAssemblyPath, "Sherlock.MCP.Tests.TestSampleClass", options);
+
+        Assert.NotEmpty(methods);
+        var modifiers = methods.Select(m => m.AccessModifier).ToArray();
+        Assert.Equal(modifiers.OrderBy(m => m), modifiers);
+    }
+}


### PR DESCRIPTION
## Summary

Phase A of the repo review: correctness fixes and performance improvements across the runtime and tool layers.

### Correctness
- **Stale cache fix**: tool cache keys and continuation-token salts now include the assembly file stamp (mtime + length) via `CacheKeyHelper.FileStamp`, so a rebuilt DLL invalidates cached responses immediately instead of serving stale JSON for the TTL window.
- **Thread-safety fix**: `XmlDocService` (singleton) used an unsynchronized `Dictionary` cache; now a `ConcurrentDictionary` holding a per-file member-id index — lookups go from linear XML scans to dictionary hits, stamp-validated and bounded.
- `sortBy=access` was accepted but silently ignored; now implemented.

### Performance
- **`SharedInspectionContextProvider`**: single bounded (LRU, `MaxLoadedAssemblies`, default 64), mtime-validated, lease-based cache of `MetadataLoadContext`s shared by all services and tools. Previously each tool call parsed assembly metadata twice (tool-level + service-level contexts), and two services kept separate unbounded, never-invalidated caches.
- **Paginate before materializing**: new `Get*Page` service APIs (`PagedResult<T>`) filter/sort on raw `MemberInfo` and build details/signatures only for the requested window.
- **Parallel reverse lookup**: `FindImplementationsOf` / `FindMethodsReturning` / `FindReferencesTo` scan assemblies with `Parallel.ForEach` + shared contexts, interlocked hard cap. Deterministic output ordering preserved.
- **Bounded response cache**: expiry sweep + oldest-expiring eviction (`MaxCachedResponses`, default 256).

### Misc
- Consolidated three duplicate friendly-type-name formatters into `TypeNameFormatter` (reverse-lookup signatures now render `Nullable<T>` as `T?`, consistent with member analysis).
- New limits exposed via `GetRuntimeOptions` / `UpdateRuntimeOptions`.
- Release workflow now publishes to the MCP Registry via GitHub OIDC.
- Tool count corrected to 32 in README/CLAUDE.md.

## Testing
- 10 new regression tests (concurrent XML doc access, file-stamp invalidation, bounded cache, provider freshness after rebuild, concurrent acquire under LRU pressure, paged/unpaged parity, access sort).
- Full suite passes: 129 unit tests on net8.0/net10.0 + integration tests (net9.0 runtime not installed locally; CI covers it).
- Manual stdio smoke test: `tools/list` → 32 tools; `get_type_methods` pages correctly with continuation token; simple-name resolution works in `get_type_hierarchy`.