### PR TITLE
fix(runtime): parse .slnx solutions in AnalyzeSolution

### DIFF
--- a/src/runtime/ProjectAnalysisService.cs
+++ b/src/runtime/ProjectAnalysisService.cs
@@ -22,6 +22,13 @@ public class ProjectAnalysisService : IProjectAnalysisService
         }
         var solutionDirectory = Path.GetDirectoryName(solutionFilePath) ?? string.Empty;
         var content = await File.ReadAllTextAsync(solutionFilePath);
+        return Path.GetExtension(solutionFilePath).Equals(".slnx", StringComparison.OrdinalIgnoreCase)
+            ? ParseSlnxProjects(content, solutionDirectory)
+            : ParseSlnProjects(content, solutionDirectory);
+    }
+
+    private static ProjectInfo[] ParseSlnProjects(string content, string solutionDirectory)
+    {
         var projects = new List<ProjectInfo>();
         var matches = SolutionProjectRegex.Matches(content);
         foreach (Match match in matches)
@@ -41,6 +48,30 @@ public class ProjectAnalysisService : IProjectAnalysisService
                 fullPath,
                 projectGuid,
                 projectTypeGuid
+            ));
+        }
+        return projects.ToArray();
+    }
+
+    private static ProjectInfo[] ParseSlnxProjects(string content, string solutionDirectory)
+    {
+        var doc = XDocument.Parse(content);
+        var projects = new List<ProjectInfo>();
+        foreach (var element in doc.Descendants("Project"))
+        {
+            var relativePath = element.Attribute("Path")?.Value;
+            if (string.IsNullOrWhiteSpace(relativePath))
+                continue;
+            if (!SupportedProjectExtensions.Any(ext => relativePath.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
+                continue;
+            var normalized = relativePath.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+            var fullPath = Path.GetFullPath(Path.Combine(solutionDirectory, normalized));
+            projects.Add(new ProjectInfo(
+                Path.GetFileNameWithoutExtension(normalized),
+                relativePath,
+                fullPath,
+                string.Empty,
+                string.Empty
             ));
         }
         return projects.ToArray();
@@ -342,19 +373,24 @@ public class ProjectAnalysisService : IProjectAnalysisService
         if (versions.Length == 0)
             return null;
         var parsed = versions
-            .Select(v => (raw: v, parsed: TryParseVersion(v)))
+            .Select(v => (raw: v, parsed: TryParseVersion(v), isStable: !v.Contains('-')))
+            .Where(p => p.parsed is not null)
             .ToArray();
-        var withParsed = parsed.Where(p => p.parsed is not null).ToArray();
-        if (withParsed.Length > 0)
-            return withParsed.OrderByDescending(p => p.parsed!).First().raw;
+        if (parsed.Length > 0)
+            return parsed
+                .OrderByDescending(p => p.isStable)
+                .ThenByDescending(p => p.parsed!)
+                .First().raw;
         return versions.OrderByDescending(v => v, StringComparer.OrdinalIgnoreCase).First();
     }
 
     private static Version? TryParseVersion(string raw)
     {
-        if (raw.Contains('-'))
-            return null;
-        return Version.TryParse(raw, out var v) ? v : null;
+        var core = raw.AsSpan();
+        var cut = core.IndexOfAny('-', '+');
+        if (cut >= 0)
+            core = core[..cut];
+        return Version.TryParse(core, out var v) ? v : null;
     }
 
     private static string[] SortVersionsDescending(string[] versions)

--- a/src/runtime/ProjectAnalysisService.cs
+++ b/src/runtime/ProjectAnalysisService.cs
@@ -380,6 +380,7 @@ public class ProjectAnalysisService : IProjectAnalysisService
             return parsed
                 .OrderByDescending(p => p.isStable)
                 .ThenByDescending(p => p.parsed!)
+                .ThenByDescending(p => p.raw, StringComparer.OrdinalIgnoreCase)
                 .First().raw;
         return versions.OrderByDescending(v => v, StringComparer.OrdinalIgnoreCase).First();
     }

--- a/src/unit-tests/ProjectAnalysisServiceTests.cs
+++ b/src/unit-tests/ProjectAnalysisServiceTests.cs
@@ -329,6 +329,20 @@ public class ProjectAnalysisServiceTests
         Assert.StartsWith(cache.Path, result.FoundAssembly!);
     }
 
+    [Fact]
+    public async Task FindAssemblyInNugetCache_Picks_Highest_PreRelease_When_No_Stable()
+    {
+        using var cache = new TempDir();
+        SeedPackage(cache.Path, "Pre.Pkg", "2.0.0-alpha", "net9.0");
+        SeedPackage(cache.Path, "Pre.Pkg", "2.0.0-beta", "net9.0");
+        using var _ = new EnvVar("NUGET_PACKAGES", cache.Path);
+
+        var result = await _service.FindAssemblyInNugetCacheAsync("Pre.Pkg");
+
+        Assert.Null(result.Failure);
+        Assert.Equal("2.0.0-beta", result.ResolvedVersion);
+    }
+
     private static void SeedPackage(string cacheRoot, string packageId, string version, string tfm)
     {
         var tfmDir = Path.Combine(cacheRoot, packageId.ToLowerInvariant(), version, "lib", tfm);

--- a/src/unit-tests/ProjectAnalysisServiceTests.cs
+++ b/src/unit-tests/ProjectAnalysisServiceTests.cs
@@ -35,6 +35,40 @@ public class ProjectAnalysisServiceTests
     }
 
     [Fact]
+    public async Task AnalyzeSolutionFile_Parses_Slnx_Projects_Including_Nested_And_Filtered()
+    {
+        using var temp = new TempDir();
+        var appDir = Path.Combine(temp.Path, "src", "App");
+        var libDir = Path.Combine(temp.Path, "src", "Lib");
+        Directory.CreateDirectory(appDir);
+        Directory.CreateDirectory(libDir);
+        await File.WriteAllTextAsync(Path.Combine(appDir, "App.csproj"), MinimalCsproj());
+        await File.WriteAllTextAsync(Path.Combine(libDir, "Lib.csproj"), MinimalCsproj());
+
+        var slnx = """
+<Solution>
+  <Project Path="src/App/App.csproj" />
+  <Folder Name="/Libraries/">
+    <Project Path="src/Lib/Lib.csproj" />
+  </Folder>
+  <Project Path="docs/readme.md" />
+</Solution>
+""";
+        var slnxPath = Path.Combine(temp.Path, "Test.slnx");
+        await File.WriteAllTextAsync(slnxPath, slnx);
+
+        var projects = await _service.AnalyzeSolutionFileAsync(slnxPath);
+
+        Assert.Equal(2, projects.Length);
+        var app = projects.Single(p => p.Name == "App");
+        var lib = projects.Single(p => p.Name == "Lib");
+        Assert.EndsWith("src/App/App.csproj", app.RelativePath.Replace('\\', '/'));
+        Assert.EndsWith("src/Lib/Lib.csproj", lib.RelativePath.Replace('\\', '/'));
+        Assert.True(File.Exists(app.FullPath));
+        Assert.True(File.Exists(lib.FullPath));
+    }
+
+    [Fact]
     public async Task AnalyzeProjectFile_Parses_Metadata_And_References()
     {
         using var temp = new TempDir();


### PR DESCRIPTION
## Summary

`AnalyzeSolutionFileAsync` only understood the classic `.sln` text format, so the newer XML `.slnx` format — including this repo's own `src/Sherlock.MCP.slnx` — silently returned zero projects.

- Branch on file extension: `.slnx` → `XDocument`-parse `<Project Path>` elements (`Descendants` so `<Folder>`-nested projects are included), filtered to `.csproj/.vbproj/.fsproj`; `.sln` → existing regex path (extracted to `ParseSlnProjects`).
- Harden `TryParseVersion` to trim at `-`/`+` before `Version.TryParse` so semver prerelease/build-metadata suffixes parse instead of being discarded.
- Make `PickHighestVersion`'s stable-over-prerelease preference explicit, since the old null-on-prerelease behavior was implicitly providing it.

Closes #37.

## Test plan

- New unit test `AnalyzeSolutionFile_Parses_Slnx_Projects_Including_Nested_And_Filtered` covers a nested `<Folder>` project and a non-project path that must be filtered out.
- Existing `.sln` test and NuGet version-selection tests remain green.
- `dotnet test -f net10.0`: all 130 pass (net8.0 also passes; net9.0 runtime not installed locally).