### PR TITLE
feat: add SearchMembers tool for assembly-wide member search

### DIFF
--- a/src/runtime/Contracts/Search/MemberSearchHit.cs
+++ b/src/runtime/Contracts/Search/MemberSearchHit.cs
@@ -1,0 +1,12 @@
+namespace Sherlock.MCP.Runtime.Contracts.Search;
+
+public record MemberSearchHit(
+    string DeclaringType,
+    string MemberKind,
+    string Name,
+    string Signature);
+
+public record SearchOptions(
+    bool CaseSensitive = false,
+    bool IncludeNonPublic = false,
+    IReadOnlySet<string>? MemberKinds = null);

--- a/src/runtime/ISearchService.cs
+++ b/src/runtime/ISearchService.cs
@@ -1,0 +1,10 @@
+using Sherlock.MCP.Runtime.Contracts.Common;
+using Sherlock.MCP.Runtime.Contracts.Search;
+
+namespace Sherlock.MCP.Runtime;
+
+public interface ISearchService
+{
+    PagedResult<MemberSearchHit> SearchMembers(
+        string assemblyPath, string nameContains, SearchOptions options, int offset, int pageSize);
+}

--- a/src/runtime/RuntimeOptions.cs
+++ b/src/runtime/RuntimeOptions.cs
@@ -25,7 +25,8 @@ public class RuntimeOptions
             ["GetTypesFromAssembly"] = 50, // Type summaries
             ["FindImplementationsOf"] = 50,
             ["FindMethodsReturning"] = 50,
-            ["FindReferencesTo"] = 25      // Broader sweep, keep smaller
+            ["FindReferencesTo"] = 25,     // Broader sweep, keep smaller
+            ["SearchMembers"] = 50
         };
     }
 

--- a/src/runtime/SearchService.cs
+++ b/src/runtime/SearchService.cs
@@ -1,0 +1,217 @@
+using System.Reflection;
+using Sherlock.MCP.Runtime.Contracts.Common;
+using Sherlock.MCP.Runtime.Contracts.Search;
+using Sherlock.MCP.Runtime.Inspection;
+
+namespace Sherlock.MCP.Runtime;
+
+public class SearchService : ISearchService
+{
+    private readonly IInspectionContextProvider _contexts;
+
+    public SearchService() : this(new SharedInspectionContextProvider(new RuntimeOptions()))
+    {
+    }
+
+    public SearchService(IInspectionContextProvider contexts) => _contexts = contexts;
+
+    public PagedResult<MemberSearchHit> SearchMembers(
+        string assemblyPath, string nameContains, SearchOptions options, int offset, int pageSize)
+    {
+        var comparison = options.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        var flags = BuildMemberFlags(options);
+
+        bool WantsKind(string kind) => options.MemberKinds == null || options.MemberKinds.Contains(kind);
+        bool NameMatches(string name) => name.Contains(nameContains, comparison);
+
+        var candidates = new List<Candidate>();
+
+        try
+        {
+            using var lease = _contexts.Acquire(assemblyPath);
+            var ctx = lease.Context;
+
+            foreach (var type in GetScannableTypes(ctx, options))
+            {
+                if (WantsKind("type") && NameMatches(type.Name))
+                    candidates.Add(new Candidate(DeclaringTypeOf(type), "type", FriendlyTypeName(type), TokenOf(type), type));
+
+                var declaringName = TypeNameFormatter.FriendlyFullName(type);
+
+                if (WantsKind("method"))
+                    foreach (var method in GetMethodsSafe(type, flags))
+                        if (NameMatches(method.Name))
+                            candidates.Add(new Candidate(declaringName, "method", method.Name, TokenOf(method), method));
+
+                if (WantsKind("property"))
+                    foreach (var prop in GetPropertiesSafe(type, flags))
+                        if (NameMatches(prop.Name))
+                            candidates.Add(new Candidate(declaringName, "property", prop.Name, TokenOf(prop), prop));
+
+                if (WantsKind("field"))
+                    foreach (var field in GetFieldsSafe(type, flags))
+                        if (NameMatches(field.Name))
+                            candidates.Add(new Candidate(declaringName, "field", field.Name, TokenOf(field), field));
+
+                if (WantsKind("event"))
+                    foreach (var evt in GetEventsSafe(type, flags))
+                        if (NameMatches(evt.Name))
+                            candidates.Add(new Candidate(declaringName, "event", evt.Name, TokenOf(evt), evt));
+            }
+
+            var sorted = candidates
+                .OrderBy(c => c.DeclaringType, StringComparer.Ordinal)
+                .ThenBy(c => c.MemberKind, StringComparer.Ordinal)
+                .ThenBy(c => c.Name, StringComparer.Ordinal)
+                .ThenBy(c => c.Token)
+                .ToArray();
+
+            var page = sorted
+                .Skip(Math.Max(0, offset))
+                .Take(Math.Max(0, pageSize))
+                .Select(BuildHit)
+                .ToArray();
+
+            return new PagedResult<MemberSearchHit>(sorted.Length, page);
+        }
+        catch (BadImageFormatException) { return Empty; }
+        catch (FileLoadException) { return Empty; }
+        catch (FileNotFoundException) { return Empty; }
+        catch (ReflectionTypeLoadException) { return Empty; }
+        catch (IOException) { return Empty; }
+    }
+
+    private static readonly PagedResult<MemberSearchHit> Empty = new(0, Array.Empty<MemberSearchHit>());
+
+    private readonly record struct Candidate(
+        string DeclaringType, string MemberKind, string Name, int Token, object Member);
+
+    private static MemberSearchHit BuildHit(Candidate c)
+    {
+        var signature = c.Member switch
+        {
+            MethodInfo m => FormatMethodSignature(m),
+            PropertyInfo p => FormatPropertySignature(p),
+            FieldInfo f => FormatFieldSignature(f),
+            EventInfo e => FormatEventSignature(e),
+            Type t => FormatTypeSignature(t),
+            _ => c.Name
+        };
+        return new MemberSearchHit(c.DeclaringType, c.MemberKind, c.Name, signature);
+    }
+
+    private static string DeclaringTypeOf(Type type)
+    {
+        if (type.IsNested && type.DeclaringType != null)
+            return TypeNameFormatter.FriendlyFullName(type.DeclaringType);
+        return type.Namespace ?? string.Empty;
+    }
+
+    private static int TokenOf(MemberInfo member)
+    {
+        try { return member.MetadataToken; }
+        catch { return 0; }
+    }
+
+    private static string FormatPropertySignature(PropertyInfo prop)
+    {
+        string pt;
+        try { pt = FriendlyTypeName(prop.PropertyType); }
+        catch { pt = "?"; }
+        return $"{pt} {prop.Name}";
+    }
+
+    private static string FormatFieldSignature(FieldInfo field)
+    {
+        string ft;
+        try { ft = FriendlyTypeName(field.FieldType); }
+        catch { ft = "?"; }
+        return $"{ft} {field.Name}";
+    }
+
+    private static string FormatEventSignature(EventInfo evt)
+    {
+        string et;
+        try { et = evt.EventHandlerType != null ? FriendlyTypeName(evt.EventHandlerType) : "?"; }
+        catch { et = "?"; }
+        return $"event {et} {evt.Name}";
+    }
+
+    private static string FormatTypeSignature(Type type)
+    {
+        var keyword = type.IsInterface ? "interface"
+            : type.IsEnum ? "enum"
+            : type.IsValueType ? "struct"
+            : "class";
+        return $"{keyword} {TypeNameFormatter.FriendlyFullName(type)}";
+    }
+
+    private static BindingFlags BuildMemberFlags(SearchOptions options)
+    {
+        var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+        if (options.IncludeNonPublic) flags |= BindingFlags.NonPublic;
+        return flags;
+    }
+
+    private static IEnumerable<Type> GetScannableTypes(IAssemblyInspectionContext ctx, SearchOptions options)
+    {
+        IEnumerable<Type> types;
+        try { types = ctx.GetTypes(); }
+        catch { yield break; }
+
+        foreach (var t in types)
+        {
+            if (t == null) continue;
+            if (t.IsGenericParameter) continue;
+            if (!options.IncludeNonPublic && !t.IsPublic && !t.IsNestedPublic) continue;
+            yield return t;
+        }
+    }
+
+    private static MethodInfo[] GetMethodsSafe(Type t, BindingFlags flags)
+    {
+        try { return t.GetMethods(flags).Where(m => !m.IsSpecialName).ToArray(); }
+        catch { return Array.Empty<MethodInfo>(); }
+    }
+
+    private static PropertyInfo[] GetPropertiesSafe(Type t, BindingFlags flags)
+    {
+        try { return t.GetProperties(flags); }
+        catch { return Array.Empty<PropertyInfo>(); }
+    }
+
+    private static FieldInfo[] GetFieldsSafe(Type t, BindingFlags flags)
+    {
+        try { return t.GetFields(flags); }
+        catch { return Array.Empty<FieldInfo>(); }
+    }
+
+    private static EventInfo[] GetEventsSafe(Type t, BindingFlags flags)
+    {
+        try { return t.GetEvents(flags); }
+        catch { return Array.Empty<EventInfo>(); }
+    }
+
+    private static string FormatMethodSignature(MethodInfo m)
+    {
+        string ret;
+        try { ret = FriendlyTypeName(m.ReturnType); }
+        catch { ret = "?"; }
+
+        ParameterInfo[] parameters;
+        try { parameters = m.GetParameters(); }
+        catch { parameters = Array.Empty<ParameterInfo>(); }
+
+        var ps = string.Join(", ", parameters.Select(p =>
+        {
+            string pt;
+            try { pt = FriendlyTypeName(p.ParameterType); }
+            catch { pt = "?"; }
+            return $"{pt} {p.Name}";
+        }));
+
+        return $"{ret} {m.Name}({ps})";
+    }
+
+    private static string FriendlyTypeName(Type t) => TypeNameFormatter.FriendlyName(t);
+}

--- a/src/server/Program.cs
+++ b/src/server/Program.cs
@@ -38,6 +38,7 @@ builder.Services
     .AddSingleton<IXmlDocService, XmlDocService>()
     .AddSingleton<IProjectAnalysisService, ProjectAnalysisService>()
     .AddSingleton<IReverseLookupService, ReverseLookupService>()
+    .AddSingleton<ISearchService, SearchService>()
     .AddSingleton<ToolMiddleware>()
     .AddMcpServer()
     .WithStdioServerTransport()

--- a/src/server/Tools/SearchTools.cs
+++ b/src/server/Tools/SearchTools.cs
@@ -1,0 +1,146 @@
+using ModelContextProtocol.Server;
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Contracts.Search;
+using Sherlock.MCP.Server.Middleware;
+using Sherlock.MCP.Server.Shared;
+using System.ComponentModel;
+using System.Text.Json;
+
+namespace Sherlock.MCP.Server.Tools;
+
+[McpServerToolType]
+public static class SearchTools
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+
+    private static readonly HashSet<string> ValidKinds =
+        new(StringComparer.OrdinalIgnoreCase) { "method", "property", "field", "event", "type" };
+
+    [McpServerTool]
+    [Description("Searches an assembly for members whose name contains a fragment, without needing to know the declaring type first. Answers the inverse of GetTypeMethods/Properties (e.g., 'where is ParseConnectionString defined?'). Returns a lean summary ({ declaringType, memberKind, name, signature }) by default. Pass projection='full' to add assemblyPath. Filter by memberKinds (csv: method|property|field|event|type).")]
+    public static string SearchMembers(
+        ISearchService searchService,
+        ToolMiddleware middleware,
+        RuntimeOptions runtimeOptions,
+        [Description("Path to the .NET assembly file (.dll or .exe)")] string assemblyPath,
+        [Description("Substring to match against member names (required). Case-insensitive unless caseSensitive=true.")] string nameContains,
+        [Description("Member kinds to include, csv from: method|property|field|event|type. Default: all kinds.")] string? memberKinds = null,
+        [Description("Include non-public members and types (default: false)")] bool includeNonPublic = false,
+        [Description("Case sensitive name matching (default: false)")] bool caseSensitive = false,
+        [Description("Maximum items to return (default: 50)")] int? maxItems = null,
+        [Description("Items to skip (paging)")] int? skip = null,
+        [Description("Continuation token for paging")] string? continuationToken = null,
+        [Description("Response shape. 'summary' (default, token-lean): { declaringType, memberKind, name, signature }. 'full': adds assemblyPath.")] string projection = "summary",
+        [Description("Bypass cache for this request")] bool noCache = false)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(assemblyPath))
+                return JsonHelpers.Error("InvalidArgument", "assemblyPath is required");
+            if (!File.Exists(assemblyPath))
+                return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
+            if (string.IsNullOrWhiteSpace(nameContains))
+                return JsonHelpers.Error("InvalidArgument", "nameContains is required");
+
+            var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
+            if (normalizedProjection != "summary" && normalizedProjection != "full")
+                return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
+
+            IReadOnlySet<string>? kinds = null;
+            string normalizedKinds = "all";
+            if (!string.IsNullOrWhiteSpace(memberKinds))
+            {
+                var parsed = memberKinds
+                    .Split(new[] { ',', '|' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(k => k.ToLowerInvariant())
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                var invalid = parsed.Where(k => !ValidKinds.Contains(k)).ToArray();
+                if (invalid.Length > 0)
+                    return JsonHelpers.Error("InvalidArgument", $"Unknown memberKinds: {string.Join(", ", invalid)}. Valid: method, property, field, event, type.");
+                if (parsed.Count > 0)
+                {
+                    kinds = parsed;
+                    normalizedKinds = string.Join(",", parsed.OrderBy(k => k, StringComparer.Ordinal));
+                }
+            }
+
+            var assemblyStamp = CacheKeyHelper.FileStamp(assemblyPath);
+            var saltSeed = CacheKeyHelper.Build(
+                "search.members.salt",
+                assemblyStamp, nameContains, normalizedKinds, caseSensitive, includeNonPublic);
+
+            var cacheKey = CacheKeyHelper.Build(
+                "search.members",
+                assemblyStamp, nameContains, normalizedKinds, caseSensitive, includeNonPublic, maxItems, continuationToken, skip, normalizedProjection);
+
+            return middleware.Execute(cacheKey, () =>
+            {
+                var defaultPageSize = runtimeOptions.GetMaxItemsForTool("SearchMembers");
+                var pageSize = Math.Max(1, maxItems ?? defaultPageSize);
+                var offset = 0;
+                var salt = TokenHelper.MakeSalt(saltSeed);
+
+                if (!string.IsNullOrWhiteSpace(continuationToken))
+                {
+                    if (!TokenHelper.TryParse(continuationToken!, out offset, out var parsedSalt) || parsedSalt != salt)
+                        return JsonHelpers.Error("InvalidContinuationToken", "The continuation token is invalid or expired.");
+                }
+                else if (skip.HasValue && skip.Value > 0)
+                {
+                    offset = skip.Value;
+                }
+
+                var options = new SearchOptions(
+                    CaseSensitive: caseSensitive,
+                    IncludeNonPublic: includeNonPublic,
+                    MemberKinds: kinds);
+
+                var pageResult = searchService.SearchMembers(assemblyPath, nameContains, options, offset, pageSize);
+                var page = pageResult.Items;
+
+                string? nextToken = null;
+                var nextOffset = offset + page.Length;
+                if (nextOffset < pageResult.Total) nextToken = TokenHelper.Make(nextOffset, salt);
+
+                object results = normalizedProjection == "summary"
+                    ? page.Select(h => new
+                    {
+                        declaringType = h.DeclaringType,
+                        memberKind = h.MemberKind,
+                        name = h.Name,
+                        signature = h.Signature
+                    }).ToArray()
+                    : page.Select(h => new
+                    {
+                        declaringType = h.DeclaringType,
+                        memberKind = h.MemberKind,
+                        name = h.Name,
+                        signature = h.Signature,
+                        assemblyPath
+                    }).ToArray();
+
+                var resultsJson = JsonSerializer.Serialize(results, SerializerOptions);
+                var result = new
+                {
+                    assemblyPath,
+                    nameContains,
+                    projection = normalizedProjection,
+                    total = pageResult.Total,
+                    count = page.Length,
+                    nextToken,
+                    pagination = PaginationMetadata.Create(pageResult.Total, page.Length, nextToken, resultsJson.Length),
+                    results
+                };
+
+                var sizeError = ResponseSizeHelper.ValidateResponseSize(result, "SearchMembers");
+                if (sizeError != null) return sizeError;
+
+                return JsonHelpers.Envelope("search.members", result);
+            }, noCache);
+        }
+        catch (Exception ex)
+        {
+            return JsonHelpers.Error("InternalError", $"Failed to search members: {ex.Message}");
+        }
+    }
+}

--- a/src/server/Tools/SearchTools.cs
+++ b/src/server/Tools/SearchTools.cs
@@ -17,7 +17,7 @@ public static class SearchTools
         new(StringComparer.OrdinalIgnoreCase) { "method", "property", "field", "event", "type" };
 
     [McpServerTool]
-    [Description("Searches an assembly for members whose name contains a fragment, without needing to know the declaring type first. Answers the inverse of GetTypeMethods/Properties (e.g., 'where is ParseConnectionString defined?'). Returns a lean summary ({ declaringType, memberKind, name, signature }) by default. Pass projection='full' to add assemblyPath. Filter by memberKinds (csv: method|property|field|event|type).")]
+    [Description("Searches an assembly for members whose name contains a fragment, without needing to know the declaring type first. Answers the inverse of GetTypeMethods/Properties (e.g., 'where is ParseConnectionString defined?'). Each hit is { declaringType, memberKind, name, signature }; the searched assemblyPath is echoed once at the top level. Filter by memberKinds (csv: method|property|field|event|type).")]
     public static string SearchMembers(
         ISearchService searchService,
         ToolMiddleware middleware,
@@ -30,7 +30,6 @@ public static class SearchTools
         [Description("Maximum items to return (default: 50)")] int? maxItems = null,
         [Description("Items to skip (paging)")] int? skip = null,
         [Description("Continuation token for paging")] string? continuationToken = null,
-        [Description("Response shape. 'summary' (default, token-lean): { declaringType, memberKind, name, signature }. 'full': adds assemblyPath.")] string projection = "summary",
         [Description("Bypass cache for this request")] bool noCache = false)
     {
         try
@@ -41,10 +40,6 @@ public static class SearchTools
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
             if (string.IsNullOrWhiteSpace(nameContains))
                 return JsonHelpers.Error("InvalidArgument", "nameContains is required");
-
-            var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
-            if (normalizedProjection != "summary" && normalizedProjection != "full")
-                return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
 
             IReadOnlySet<string>? kinds = null;
             string normalizedKinds = "all";
@@ -71,7 +66,7 @@ public static class SearchTools
 
             var cacheKey = CacheKeyHelper.Build(
                 "search.members",
-                assemblyStamp, nameContains, normalizedKinds, caseSensitive, includeNonPublic, maxItems, continuationToken, skip, normalizedProjection);
+                assemblyStamp, nameContains, normalizedKinds, caseSensitive, includeNonPublic, maxItems, continuationToken, skip);
 
             return middleware.Execute(cacheKey, () =>
             {
@@ -102,29 +97,19 @@ public static class SearchTools
                 var nextOffset = offset + page.Length;
                 if (nextOffset < pageResult.Total) nextToken = TokenHelper.Make(nextOffset, salt);
 
-                object results = normalizedProjection == "summary"
-                    ? page.Select(h => new
-                    {
-                        declaringType = h.DeclaringType,
-                        memberKind = h.MemberKind,
-                        name = h.Name,
-                        signature = h.Signature
-                    }).ToArray()
-                    : page.Select(h => new
-                    {
-                        declaringType = h.DeclaringType,
-                        memberKind = h.MemberKind,
-                        name = h.Name,
-                        signature = h.Signature,
-                        assemblyPath
-                    }).ToArray();
+                var results = page.Select(h => new
+                {
+                    declaringType = h.DeclaringType,
+                    memberKind = h.MemberKind,
+                    name = h.Name,
+                    signature = h.Signature
+                }).ToArray();
 
                 var resultsJson = JsonSerializer.Serialize(results, SerializerOptions);
                 var result = new
                 {
                     assemblyPath,
                     nameContains,
-                    projection = normalizedProjection,
                     total = pageResult.Total,
                     count = page.Length,
                     nextToken,

--- a/src/unit-tests/SearchServiceTests.cs
+++ b/src/unit-tests/SearchServiceTests.cs
@@ -1,0 +1,113 @@
+using System.Reflection;
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Contracts.Search;
+
+namespace Sherlock.MCP.Tests;
+
+public class SearchServiceTests
+{
+    private readonly ISearchService _svc = new SearchService();
+    private readonly string _testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+    private static SearchOptions Options(
+        bool caseSensitive = false, bool includeNonPublic = false, params string[] kinds) =>
+        new(CaseSensitive: caseSensitive,
+            IncludeNonPublic: includeNonPublic,
+            MemberKinds: kinds.Length == 0 ? null : kinds.ToHashSet(StringComparer.OrdinalIgnoreCase));
+
+    [Fact]
+    public void SearchMembers_FindsMethodsAcrossTypes_ByNameFragment()
+    {
+        var result = _svc.SearchMembers(_testAssemblyPath, "Method", Options(), offset: 0, pageSize: 1000);
+
+        var methodNames = result.Items
+            .Where(h => h.MemberKind == "method")
+            .Select(h => h.Name)
+            .ToHashSet();
+
+        Assert.Contains("StaticMethod", methodNames);
+        Assert.Contains("VirtualMethod", methodNames);
+        Assert.Contains("MethodWithParameters", methodNames);
+        Assert.Contains("GenericMethod", methodNames);
+        Assert.All(result.Items, h => Assert.Contains("Method", h.Name));
+        Assert.All(result.Items, h => Assert.False(string.IsNullOrEmpty(h.Signature)));
+    }
+
+    [Fact]
+    public void SearchMembers_KindFilter_ReturnsOnlyRequestedKind()
+    {
+        var result = _svc.SearchMembers(
+            _testAssemblyPath, "Property", Options(kinds: "property"), offset: 0, pageSize: 1000);
+
+        Assert.NotEmpty(result.Items);
+        Assert.All(result.Items, h => Assert.Equal("property", h.MemberKind));
+        Assert.Contains(result.Items, h => h.Name == "PublicProperty");
+    }
+
+    [Fact]
+    public void SearchMembers_IncludeNonPublic_ChangesResults()
+    {
+        var publicOnly = _svc.SearchMembers(
+            _testAssemblyPath, "Property", Options(kinds: "property"), offset: 0, pageSize: 1000);
+        var withNonPublic = _svc.SearchMembers(
+            _testAssemblyPath, "Property", Options(includeNonPublic: true, kinds: "property"), offset: 0, pageSize: 1000);
+
+        Assert.DoesNotContain(publicOnly.Items, h => h.Name == "ProtectedVirtualProperty");
+        Assert.Contains(withNonPublic.Items, h => h.Name == "ProtectedVirtualProperty");
+        Assert.True(withNonPublic.Total >= publicOnly.Total);
+    }
+
+    [Fact]
+    public void SearchMembers_TypeKind_FindsTypesByName()
+    {
+        var result = _svc.SearchMembers(
+            _testAssemblyPath, "TestSampleClass", Options(kinds: "type"), offset: 0, pageSize: 1000);
+
+        Assert.Contains(result.Items, h => h.MemberKind == "type" && h.Name == "TestSampleClass");
+    }
+
+    [Fact]
+    public void SearchMembers_CaseSensitive_Filters()
+    {
+        var insensitive = _svc.SearchMembers(
+            _testAssemblyPath, "staticmethod", Options(kinds: "method"), offset: 0, pageSize: 1000);
+        var sensitive = _svc.SearchMembers(
+            _testAssemblyPath, "staticmethod", Options(caseSensitive: true, kinds: "method"), offset: 0, pageSize: 1000);
+
+        Assert.Contains(insensitive.Items, h => h.Name == "StaticMethod");
+        Assert.DoesNotContain(sensitive.Items, h => h.Name == "StaticMethod");
+    }
+
+    [Fact]
+    public void SearchMembers_Pagination_TotalStable_PagesDisjoint()
+    {
+        var first = _svc.SearchMembers(_testAssemblyPath, "Method", Options(), offset: 0, pageSize: 2);
+        var second = _svc.SearchMembers(_testAssemblyPath, "Method", Options(), offset: 2, pageSize: 2);
+
+        Assert.Equal(first.Total, second.Total);
+        Assert.True(first.Items.Length <= 2);
+
+        var firstKeys = first.Items.Select(h => $"{h.DeclaringType}.{h.Name}.{h.Signature}").ToHashSet();
+        var secondKeys = second.Items.Select(h => $"{h.DeclaringType}.{h.Name}.{h.Signature}").ToHashSet();
+        Assert.Empty(firstKeys.Intersect(secondKeys));
+    }
+
+    [Fact]
+    public void SearchMembers_OffsetPastEnd_ReturnsEmptyButTotalIntact()
+    {
+        var result = _svc.SearchMembers(_testAssemblyPath, "Method", Options(), offset: 100_000, pageSize: 50);
+
+        Assert.Empty(result.Items);
+        Assert.True(result.Total > 0);
+    }
+
+    [Fact]
+    public void SearchMembers_NoMatch_ReturnsEmpty()
+    {
+        var result = _svc.SearchMembers(
+            _testAssemblyPath, "ZzzNoSuchMemberZzz", Options(), offset: 0, pageSize: 50);
+
+        Assert.Equal(0, result.Total);
+        Assert.Empty(result.Items);
+    }
+}

--- a/src/unit-tests/SearchToolsTests.cs
+++ b/src/unit-tests/SearchToolsTests.cs
@@ -1,0 +1,129 @@
+using System.Reflection;
+using System.Text.Json;
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Caching;
+using Sherlock.MCP.Runtime.Telemetry;
+using Sherlock.MCP.Server.Middleware;
+using Sherlock.MCP.Server.Tools;
+
+namespace Sherlock.MCP.Tests;
+
+public class SearchToolsTests
+{
+    private readonly ISearchService _svc = new SearchService();
+    private readonly RuntimeOptions _runtimeOptions = new();
+    private readonly ToolMiddleware _middleware;
+    private readonly string _testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+    public SearchToolsTests()
+    {
+        var cache = new InMemoryToolResponseCache();
+        var telemetry = new NoopTelemetry();
+        _middleware = new ToolMiddleware(cache, telemetry, _runtimeOptions);
+    }
+
+    [Fact]
+    public void SearchMembers_Envelope_AndHitShape()
+    {
+        var result = SearchTools.SearchMembers(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "Method", noCache: true);
+
+        Assert.DoesNotContain("\"error\"", result);
+        var doc = JsonDocument.Parse(result);
+        Assert.Equal("search.members", doc.RootElement.GetProperty("kind").GetString());
+
+        var data = doc.RootElement.GetProperty("data");
+        Assert.Equal(_testAssemblyPath, data.GetProperty("assemblyPath").GetString());
+        Assert.Equal("Method", data.GetProperty("nameContains").GetString());
+        Assert.True(data.GetProperty("total").GetInt32() > 0);
+
+        var first = data.GetProperty("results")[0];
+        Assert.True(first.TryGetProperty("declaringType", out _));
+        Assert.True(first.TryGetProperty("memberKind", out _));
+        Assert.True(first.TryGetProperty("name", out _));
+        Assert.True(first.TryGetProperty("signature", out _));
+        Assert.False(first.TryGetProperty("assemblyPath", out _),
+            "assemblyPath should be echoed once at the top level, not on every hit");
+    }
+
+    [Fact]
+    public void SearchMembers_MemberKindsFilter_RestrictsKinds()
+    {
+        var result = SearchTools.SearchMembers(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "Property", memberKinds: "property", noCache: true);
+
+        Assert.DoesNotContain("\"error\"", result);
+        var results = JsonDocument.Parse(result).RootElement.GetProperty("data").GetProperty("results");
+        Assert.True(results.GetArrayLength() > 0);
+        foreach (var hit in results.EnumerateArray())
+            Assert.Equal("property", hit.GetProperty("memberKind").GetString());
+    }
+
+    [Fact]
+    public void SearchMembers_InvalidMemberKinds_ReturnsError()
+    {
+        var result = SearchTools.SearchMembers(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "Method", memberKinds: "method,bogus", noCache: true);
+
+        Assert.Contains("InvalidArgument", result);
+        Assert.Contains("bogus", result);
+    }
+
+    [Fact]
+    public void SearchMembers_MissingNameContains_ReturnsError()
+    {
+        var result = SearchTools.SearchMembers(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "  ", noCache: true);
+
+        Assert.Contains("InvalidArgument", result);
+    }
+
+    [Fact]
+    public void SearchMembers_AssemblyNotFound_ReturnsError()
+    {
+        var result = SearchTools.SearchMembers(
+            _svc, _middleware, _runtimeOptions,
+            "/tmp/does-not-exist.dll", "Method", noCache: true);
+
+        Assert.Contains("AssemblyNotFound", result);
+    }
+
+    [Fact]
+    public void SearchMembers_ContinuationToken_RoundTrips()
+    {
+        var page1 = SearchTools.SearchMembers(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "Method", maxItems: 1, noCache: true);
+
+        Assert.DoesNotContain("\"error\"", page1);
+        var page1Data = JsonDocument.Parse(page1).RootElement.GetProperty("data");
+        if (page1Data.GetProperty("total").GetInt32() < 2) return;
+
+        var nextToken = page1Data.GetProperty("nextToken").GetString();
+        Assert.False(string.IsNullOrEmpty(nextToken));
+
+        var page2 = SearchTools.SearchMembers(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "Method",
+            maxItems: 1, continuationToken: nextToken, noCache: true);
+
+        Assert.DoesNotContain("InvalidContinuationToken", page2);
+        Assert.DoesNotContain("\"error\"", page2);
+        Assert.Equal(1, JsonDocument.Parse(page2).RootElement.GetProperty("data").GetProperty("count").GetInt32());
+    }
+
+    [Fact]
+    public void SearchMembers_InvalidContinuationToken_ReturnsError()
+    {
+        var result = SearchTools.SearchMembers(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "Method",
+            continuationToken: "not-a-real-token", noCache: true);
+
+        Assert.Contains("InvalidContinuationToken", result);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `SearchMembers` MCP tool that searches an assembly for members (methods, properties, fields, events, types) whose name contains a given fragment — without the caller needing to know the declaring type first. This is the inverse of the existing `GetType*` tools and answers the common "where is `ParseConnectionString` defined?" question.

- New `ISearchService`/`SearchService` in `src/runtime`, mirroring `ReverseLookupService`: acquires a shared, mtime-validated `IInspectionContextProvider` lease (no raw `MetadataLoadContext`), matches names cheaply first, then builds signatures only for the returned page (the `GetMethodsPage` pre-materialization pattern). Deterministic sort by declaring type → kind → name → metadata token.
- New `SearchTools.SearchMembers` tool in `src/server`, copied from `FindMethodsReturning`: salted continuation tokens, `PaginationMetadata`, response-size validation, lean `summary` projection by default (`full` adds `assemblyPath`); `memberKinds` csv filter.
- `ToolSpecificMaxItems["SearchMembers"] = 50` and DI registration.

Closes #33.

## Test plan

- `dotnet build` — clean (only pre-existing fixture warnings).
- `dotnet test` — full suite **139 passed, 0 failed** (run on net10.0; net9.0 runtime not installed locally).
- New `SearchServiceTests` cover: cross-type name-fragment hits, kind filtering, `type` kind, `includeNonPublic`/`caseSensitive` toggles, pagination total-stability/disjointness, offset-past-end, and no-match.