### PR TITLE
build: centralize props with warnings-as-errors and analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -38,3 +38,34 @@ dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
 dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
 dotnet_style_prefer_conditional_expression_over_return = true:suggestion
 
+# Analyzer rules intentionally disabled for this reflection-domain library
+# CA1716: Identifiers should not match reserved language keywords.
+# Internal interfaces use natural names like Get/Set (e.g. IToolResponseCache); this rule
+# targets cross-language public library APIs and does not apply here.
+dotnet_diagnostic.CA1716.severity = none
+# CA1720: Identifier contains a type name.
+# Contract enums deliberately mirror .NET reflection vocabulary (TypeKind.Pointer, Array, ByRef);
+# renaming would distort the domain model and change tool output contracts.
+dotnet_diagnostic.CA1720.severity = none
+
+# Test projects: relax library-design and naming analyzers that conflict with test
+# conventions and reflection fixtures. Production code (runtime/server) stays fully strict.
+[src/{unit-tests,integration-tests}/**.cs]
+# Underscored test method names (Method_Scenario_Expectation), the standard xUnit convention.
+dotnet_diagnostic.CA1707.severity = none
+# Reflection fixtures intentionally expose public fields, instance members, field-like and
+# virtual events, and custom attributes as targets for the reflection under test.
+dotnet_diagnostic.CA1051.severity = none
+dotnet_diagnostic.CA1070.severity = none
+dotnet_diagnostic.CA1822.severity = none
+dotnet_diagnostic.CA1018.severity = none
+dotnet_diagnostic.CA1715.severity = none
+dotnet_diagnostic.CS0067.severity = none
+# Minor design/perf rules that are noise in test and setup code.
+dotnet_diagnostic.CA1852.severity = none
+dotnet_diagnostic.CA1859.severity = none
+dotnet_diagnostic.CA1305.severity = none
+dotnet_diagnostic.CA1816.severity = none
+dotnet_diagnostic.CA1711.severity = none
+dotnet_diagnostic.CA1861.severity = none
+

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+  </PropertyGroup>
+
+</Project>

--- a/src/example/Sherlock.MCP.Example.csproj
+++ b/src/example/Sherlock.MCP.Example.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/integration-tests/Sherlock.MCP.IntegrationTests.csproj
+++ b/src/integration-tests/Sherlock.MCP.IntegrationTests.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/runtime/AttributeUtils.cs
+++ b/src/runtime/AttributeUtils.cs
@@ -84,7 +84,7 @@ public static class AttributeUtils
                 }
                 else if (value is byte or sbyte or short or ushort or int or uint or long or ulong)
                 {
-                    validOn = (AttributeTargets)System.Convert.ToInt64(value);
+                    validOn = (AttributeTargets)System.Convert.ToInt64(value, System.Globalization.CultureInfo.InvariantCulture);
                 }
             }
 

--- a/src/runtime/Contracts/MemberAnalysis/MemberFilterOptions.cs
+++ b/src/runtime/Contracts/MemberAnalysis/MemberFilterOptions.cs
@@ -3,10 +3,10 @@ namespace Sherlock.MCP.Runtime.Contracts.MemberAnalysis;
 public class MemberFilterOptions
 {
     public bool IncludePublic { get; set; } = true;
-    public bool IncludeNonPublic { get; set; } = false;
+    public bool IncludeNonPublic { get; set; }
     public bool IncludeStatic { get; set; } = true;
     public bool IncludeInstance { get; set; } = true;
-    public bool IncludeInherited { get; set; } = false;
+    public bool IncludeInherited { get; set; }
     public bool IncludeDeclaredOnly { get; set; } = true;
     public bool CaseSensitive { get; set; } = true;
     public string? NameContains { get; set; }

--- a/src/runtime/MemberAnalysisService.cs
+++ b/src/runtime/MemberAnalysisService.cs
@@ -100,8 +100,8 @@ public class MemberAnalysisService : IMemberAnalysisService
     }
 
     private static bool IsAccessorMethod(MethodInfo method) =>
-        method.IsSpecialName && (method.Name.StartsWith("get_") || method.Name.StartsWith("set_") ||
-            method.Name.StartsWith("add_") || method.Name.StartsWith("remove_"));
+        method.IsSpecialName && (method.Name.StartsWith("get_", StringComparison.Ordinal) || method.Name.StartsWith("set_", StringComparison.Ordinal) ||
+            method.Name.StartsWith("add_", StringComparison.Ordinal) || method.Name.StartsWith("remove_", StringComparison.Ordinal));
 
     private static MethodDetails BuildMethodDetails(MethodInfo method)
     {
@@ -348,7 +348,7 @@ public class MemberAnalysisService : IMemberAnalysisService
 
         if (!string.IsNullOrEmpty(options.NameContains))
         {
-            query = query.Where(m => m.Name.IndexOf(options.NameContains!, comparison) >= 0);
+            query = query.Where(m => m.Name.Contains(options.NameContains!, comparison));
         }
         if (!string.IsNullOrEmpty(options.HasAttributeContains))
         {
@@ -377,7 +377,7 @@ public class MemberAnalysisService : IMemberAnalysisService
 
         if (!string.IsNullOrEmpty(options.NameContains))
         {
-            query = query.Where(x => nameSelector(x).IndexOf(options.NameContains!, comparison) >= 0);
+            query = query.Where(x => nameSelector(x).Contains(options.NameContains!, comparison));
         }
         if (!string.IsNullOrEmpty(options.HasAttributeContains))
         {
@@ -394,7 +394,7 @@ public class MemberAnalysisService : IMemberAnalysisService
         try
         {
             return member.GetCustomAttributesData()
-                .Any(a => (a.AttributeType.FullName ?? a.AttributeType.Name).IndexOf(filter, comparison) >= 0);
+                .Any(a => (a.AttributeType.FullName ?? a.AttributeType.Name).Contains(filter, comparison));
         }
         catch
         {
@@ -433,7 +433,7 @@ public class MemberAnalysisService : IMemberAnalysisService
     private static bool IsOperatorMethod(MethodInfo method)
     {
         return method.IsSpecialName && method.IsStatic &&
-               (method.Name.StartsWith("op_") || method.Name == "True" || method.Name == "False");
+               (method.Name.StartsWith("op_", StringComparison.Ordinal) || method.Name == "True" || method.Name == "False");
     }
     private static bool IsExtensionMethod(MethodInfo method)
     {

--- a/src/runtime/ProjectAnalysisService.cs
+++ b/src/runtime/ProjectAnalysisService.cs
@@ -432,16 +432,16 @@ public class ProjectAnalysisService : IProjectAnalysisService
     private static (int family, Version version) RankTfm(string tfm)
     {
         var lower = tfm.ToLowerInvariant();
-        if (lower.StartsWith("net") && !lower.StartsWith("netstandard") && !lower.StartsWith("netcoreapp") && !lower.Contains("framework"))
+        if (lower.StartsWith("net", StringComparison.Ordinal) && !lower.StartsWith("netstandard", StringComparison.Ordinal) && !lower.StartsWith("netcoreapp", StringComparison.Ordinal) && !lower.Contains("framework"))
         {
             var rest = lower[3..];
             if (IsFrameworkStyleTfm(rest))
                 return (3, ParseFrameworkStyleVersion(rest));
             return (0, TryParseVersion(rest) ?? new Version(0, 0));
         }
-        if (lower.StartsWith("netcoreapp"))
+        if (lower.StartsWith("netcoreapp", StringComparison.Ordinal))
             return (1, TryParseVersion(lower[10..]) ?? new Version(0, 0));
-        if (lower.StartsWith("netstandard"))
+        if (lower.StartsWith("netstandard", StringComparison.Ordinal))
             return (2, TryParseVersion(lower[11..]) ?? new Version(0, 0));
         return (4, new Version(0, 0));
     }
@@ -488,7 +488,7 @@ public class ProjectAnalysisService : IProjectAnalysisService
         return parent.Element(childName)?.Value;
     }
 
-    private async Task<string[]> ResolvePackageAssemblyPathsAsync(PackageReference package, string[] targetFrameworks)
+    private static async Task<string[]> ResolvePackageAssemblyPathsAsync(PackageReference package, string[] targetFrameworks)
     {
         var assemblyPaths = new List<string>();
         var nugetCachePath = GetNugetCacheRoot();
@@ -551,7 +551,7 @@ public class ProjectAnalysisService : IProjectAnalysisService
     {
         if (availableFramework.Equals(targetFramework, StringComparison.OrdinalIgnoreCase))
             return true;
-        if (targetFramework.StartsWith("net") && !targetFramework.Contains("framework"))
+        if (targetFramework.StartsWith("net", StringComparison.Ordinal) && !targetFramework.Contains("framework"))
         {
             if (availableFramework.Equals("netstandard2.0", StringComparison.OrdinalIgnoreCase) ||
                 availableFramework.Equals("netstandard2.1", StringComparison.OrdinalIgnoreCase))
@@ -560,7 +560,7 @@ public class ProjectAnalysisService : IProjectAnalysisService
         return false;
     }
 
-    private async Task<RuntimeDependency[]> ParseDepsJsonFileAsync(string depsJsonPath)
+    private static async Task<RuntimeDependency[]> ParseDepsJsonFileAsync(string depsJsonPath)
     {
         var dependencies = new List<RuntimeDependency>();
         try

--- a/src/runtime/ReverseLookupService.cs
+++ b/src/runtime/ReverseLookupService.cs
@@ -166,7 +166,7 @@ public class ReverseLookupService : IReverseLookupService
                         try { pt = p.ParameterType; } catch { continue; }
                         if (FindMatchingType(pt, typeName, options.CaseSensitive) == null) continue;
                         if (!TryAdd(MakeRefHit(path, declaringName, "method", method.Name, "parameter", sig,
-                            disambiguator: p.Name ?? p.Position.ToString()))) return;
+                            disambiguator: p.Name ?? p.Position.ToString(System.Globalization.CultureInfo.InvariantCulture)))) return;
                     }
                 }
 

--- a/src/runtime/Sherlock.MCP.Runtime.csproj
+++ b/src/runtime/Sherlock.MCP.Runtime.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.6" />

--- a/src/runtime/TypeAnalysisService.cs
+++ b/src/runtime/TypeAnalysisService.cs
@@ -58,6 +58,7 @@ public class TypeAnalysisService : ITypeAnalysisService, IDisposable
             try { lease.Dispose(); } catch { }
         }
         _pinned.Clear();
+        GC.SuppressFinalize(this);
     }
 
     public TypeAnalysisInfo GetTypeInfo(Type type)

--- a/src/runtime/TypeNameMatcher.cs
+++ b/src/runtime/TypeNameMatcher.cs
@@ -69,7 +69,7 @@ public static class TypeNameMatcher
             yield return "System." + clr;
         }
 
-        if (s.EndsWith("?") && s.Length > 1)
+        if (s.EndsWith('?') && s.Length > 1)
         {
             var inner = s.Substring(0, s.Length - 1).Trim();
             yield return $"Nullable<{inner}>";

--- a/src/server/Shared/CacheKeyHelper.cs
+++ b/src/server/Shared/CacheKeyHelper.cs
@@ -28,10 +28,9 @@ public static class CacheKeyHelper
 
     public static string Sha256(string input)
     {
-        using var sha = SHA256.Create();
-        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(input));
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
         var sb = new StringBuilder(bytes.Length * 2);
-        foreach (var b in bytes) sb.Append(b.ToString("x2"));
+        foreach (var b in bytes) sb.Append(b.ToString("x2", System.Globalization.CultureInfo.InvariantCulture));
         return sb.ToString();
     }
 

--- a/src/server/Sherlock.MCP.Server.csproj
+++ b/src/server/Sherlock.MCP.Server.csproj
@@ -6,9 +6,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <PackageId>Sherlock.MCP.Server</PackageId>
   </PropertyGroup>
 

--- a/src/server/Tools/SearchTools.cs
+++ b/src/server/Tools/SearchTools.cs
@@ -16,6 +16,8 @@ public static class SearchTools
     private static readonly HashSet<string> ValidKinds =
         new(StringComparer.OrdinalIgnoreCase) { "method", "property", "field", "event", "type" };
 
+    private static readonly char[] KindSeparators = { ',', '|' };
+
     [McpServerTool]
     [Description("Searches an assembly for members whose name contains a fragment, without needing to know the declaring type first. Answers the inverse of GetTypeMethods/Properties (e.g., 'where is ParseConnectionString defined?'). Each hit is { declaringType, memberKind, name, signature }; the searched assemblyPath is echoed once at the top level. Filter by memberKinds (csv: method|property|field|event|type).")]
     public static string SearchMembers(
@@ -46,7 +48,7 @@ public static class SearchTools
             if (!string.IsNullOrWhiteSpace(memberKinds))
             {
                 var parsed = memberKinds
-                    .Split(new[] { ',', '|' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Split(KindSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                     .Select(k => k.ToLowerInvariant())
                     .ToHashSet(StringComparer.OrdinalIgnoreCase);
                 var invalid = parsed.Where(k => !ValidKinds.Contains(k)).ToArray();

--- a/src/unit-tests/Sherlock.MCP.Tests.csproj
+++ b/src/unit-tests/Sherlock.MCP.Tests.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591</NoWarn>

--- a/src/unit-tests/TestSampleClass.cs
+++ b/src/unit-tests/TestSampleClass.cs
@@ -29,6 +29,7 @@ public class TestSampleClass
     /// <summary>Method with parameters and attribute for testing</summary>
     /// <param name="required">required</param>
     /// <param name="optional">optional</param>
+    /// <param name="values">values</param>
     /// <returns>none</returns>
     [Sample]
     public void MethodWithParameters([Sample] int required, string optional = "default", params object[] values) { }


### PR DESCRIPTION
## Summary

Adds a repo-root `Directory.Build.props` to centralize build configuration and turn on warnings-as-errors plus analyzers, then cleans up the resulting fallout. Closes #42.

- **`Directory.Build.props`** (new): shared `TargetFrameworks` (`net8.0;net9.0;net10.0`), `LangVersion=latest`, `Nullable`, `ImplicitUsings`, `TreatWarningsAsErrors=true`, `AnalysisLevel=latest-recommended`. Auto-imported by all five projects.
- **5 csproj files**: removed the now-duplicated `TargetFrameworks`/`ImplicitUsings`/`Nullable`; all project-specific metadata (server packaging/container, `OutputType`, `IsPackable`, `GenerateDocumentationFile`, `NoWarn`) preserved.
- **Analyzer fallout fixed in production code** (runtime/server): ordinal `StartsWith`/`EndsWith` and `IFormatProvider` (CA1310/CA1305/CA1866), `Contains` over `IndexOf` (CA2249), static helpers (CA1822), `SHA256.HashData` + extracted constant array (CA1850/CA1861), `GC.SuppressFinalize` in `Dispose` (CA1816), removed redundant default initializers (CA1805), completed an XML `<param>` tag (CS1573).
- **`.editorconfig`**: documented analyzer policy — disabled CA1716/CA1720 project-wide (reflection-domain naming: `Get`/`Set` interfaces, `TypeKind.Pointer`/`Array`/`ByRef`), and relaxed test/fixture-pattern rules (CA1707 xUnit naming, fixture field/event/instance rules, minor perf rules) scoped to the test directories only. **Production code stays fully strict.**

## Test plan

- `dotnet build src/Sherlock.MCP.slnx -c Release` → Build succeeded, **zero warnings** across net8.0/net9.0/net10.0 (warnings now fail the build).
- `dotnet test` → 146 unit + 1 integration tests pass on net8.0 and net10.0. (net9.0 testhost skipped locally — runtime not installed on this machine; the net9.0 build compiles clean.)