### PR TITLE
feat: add FindExtensionMethodsFor reverse-lookup tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,17 +32,17 @@ This is a comprehensive .NET MCP (Model Context Protocol) server called "Sherloc
 This MCP server provides LLMs with comprehensive .NET reflection capabilities through several key architectural principles:
 
 ### Assembly-First Discovery
-Since the MCP server runs as a separate process, it cannot access the client's loaded assemblies. Instead, it provides 32 specialized tools for clients to:
+Since the MCP server runs as a separate process, it cannot access the client's loaded assemblies. Instead, it provides 33 specialized tools for clients to:
 1. **Discover assemblies** using multiple strategies (project analysis, class name search, file system scanning)
 2. **Load and analyze** specific assemblies by path with efficient caching
 3. **Deep introspection** of types, members, attributes, and XML documentation
 4. **Performance optimization** through pagination, streaming, and response size validation
 
-### Tool Categories (32 Available)
+### Tool Categories (33 Available)
 - **Assembly Discovery & Analysis** (3 tools): `AnalyzeAssembly`, `FindAssemblyByClassName`, `FindAssemblyByFileName`
 - **Type Introspection** (7 tools): `GetTypesFromAssembly`, `GetTypeInfo`, `GetTypeHierarchy`, etc.
 - **Member Analysis** (8 tools): `GetTypeMethods`, `GetTypeProperties`, `GetAllTypeMembers`, etc.
-- **Reverse Lookup** (3 tools): `FindImplementationsOf`, `FindMethodsReturning`, `FindReferencesTo`
+- **Reverse Lookup** (4 tools): `FindImplementationsOf`, `FindMethodsReturning`, `FindExtensionMethodsFor`, `FindReferencesTo`
 - **Attributes & Metadata** (2 tools): `GetMemberAttributes`, `GetParameterAttributes`
 - **XML Documentation** (2 tools): `GetXmlDocsForType`, `GetXmlDocsForMember`
 - **Project Analysis** (5 tools): `AnalyzeSolution`, `AnalyzeProject`, `ResolvePackageReferences`, etc.

--- a/src/runtime/Contracts/ReverseLookup/ExtensionMethodHit.cs
+++ b/src/runtime/Contracts/ReverseLookup/ExtensionMethodHit.cs
@@ -1,0 +1,8 @@
+namespace Sherlock.MCP.Runtime.Contracts.ReverseLookup;
+
+public record ExtensionMethodHit(
+    string AssemblyPath,
+    string DeclaringTypeFullName,
+    string MethodName,
+    string Signature,
+    string ExtendedTypeFriendlyName);

--- a/src/runtime/IReverseLookupService.cs
+++ b/src/runtime/IReverseLookupService.cs
@@ -8,6 +8,8 @@ public interface IReverseLookupService
 
     MethodReturnHit[] FindMethodsReturning(string[] assemblyPaths, string typeName, ReverseLookupOptions options);
 
+    ExtensionMethodHit[] FindExtensionMethodsFor(string[] assemblyPaths, string typeName, ReverseLookupOptions options);
+
     ReferencesResult FindReferences(string[] assemblyPaths, string typeName, ReverseLookupOptions options);
 }
 

--- a/src/runtime/ReverseLookupService.cs
+++ b/src/runtime/ReverseLookupService.cs
@@ -97,6 +97,8 @@ public class ReverseLookupService : IReverseLookupService
         {
             foreach (var candidate in GetScannableTypes(ctx, options))
             {
+                if (!IsStaticClass(candidate)) continue;
+
                 foreach (var method in GetMethodsSafe(candidate, flags))
                 {
                     if (!IsExtensionMethod(method)) continue;
@@ -415,6 +417,8 @@ public class ReverseLookupService : IReverseLookupService
     }
 
     private static string FriendlyTypeName(Type t) => TypeNameFormatter.FriendlyName(t);
+
+    private static bool IsStaticClass(Type t) => t.IsAbstract && t.IsSealed && !t.IsGenericType;
 
     private static bool IsExtensionMethod(MethodInfo method)
     {

--- a/src/runtime/ReverseLookupService.cs
+++ b/src/runtime/ReverseLookupService.cs
@@ -88,6 +88,48 @@ public class ReverseLookupService : IReverseLookupService
             .ToArray();
     }
 
+    public ExtensionMethodHit[] FindExtensionMethodsFor(string[] assemblyPaths, string typeName, ReverseLookupOptions options)
+    {
+        var hits = new ConcurrentBag<ExtensionMethodHit>();
+        var flags = BuildMemberFlags(options);
+
+        ScanInParallel(assemblyPaths, (path, ctx) =>
+        {
+            foreach (var candidate in GetScannableTypes(ctx, options))
+            {
+                foreach (var method in GetMethodsSafe(candidate, flags))
+                {
+                    if (!IsExtensionMethod(method)) continue;
+
+                    ParameterInfo[] parameters;
+                    try { parameters = method.GetParameters(); }
+                    catch { continue; }
+                    if (parameters.Length == 0) continue;
+
+                    Type extendedType;
+                    try { extendedType = parameters[0].ParameterType; }
+                    catch { continue; }
+
+                    if (!TypeNameMatcher.Matches(extendedType, typeName, options.CaseSensitive)) continue;
+
+                    hits.Add(new ExtensionMethodHit(
+                        AssemblyPath: path,
+                        DeclaringTypeFullName: TypeNameFormatter.FriendlyFullName(candidate),
+                        MethodName: method.Name,
+                        Signature: FormatMethodSignature(method),
+                        ExtendedTypeFriendlyName: FriendlyTypeName(extendedType)));
+                }
+            }
+        });
+
+        return hits
+            .OrderBy(h => h.AssemblyPath, StringComparer.Ordinal)
+            .ThenBy(h => h.DeclaringTypeFullName, StringComparer.Ordinal)
+            .ThenBy(h => h.MethodName, StringComparer.Ordinal)
+            .ThenBy(h => h.Signature, StringComparer.Ordinal)
+            .ToArray();
+    }
+
     public ReferencesResult FindReferences(string[] assemblyPaths, string typeName, ReverseLookupOptions options)
     {
         var hits = new ConcurrentBag<ReferenceHit>();
@@ -373,4 +415,14 @@ public class ReverseLookupService : IReverseLookupService
     }
 
     private static string FriendlyTypeName(Type t) => TypeNameFormatter.FriendlyName(t);
+
+    private static bool IsExtensionMethod(MethodInfo method)
+    {
+        if (!method.IsStatic) return false;
+        try
+        {
+            return method.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.ExtensionAttribute");
+        }
+        catch { return false; }
+    }
 }

--- a/src/server/Tools/ReverseLookupTools.cs
+++ b/src/server/Tools/ReverseLookupTools.cs
@@ -204,6 +204,103 @@ public static class ReverseLookupTools
     }
 
     [McpServerTool]
+    [Description("Finds extension methods that extend the given type, across one or more assemblies. Scans static classes for methods whose first ('this') parameter matches the target type. Returns a lean summary ({ declaringType, methodName, signature }) by default. Pass projection='full' for assemblyPath and extendedType. Open-generic match supported (e.g., 'IEnumerable<>' matches extensions on 'IEnumerable<T>').")]
+    public static string FindExtensionMethodsFor(
+        IReverseLookupService reverseLookup,
+        ToolMiddleware middleware,
+        RuntimeOptions runtimeOptions,
+        [Description("Path to the primary .NET assembly file (.dll or .exe)")] string assemblyPath,
+        [Description("Type to find extension methods for. Simple name, full name, or open-generic form accepted (e.g., 'IEnumerable<>').")] string typeName,
+        [Description("Optional additional assembly paths to include in the search scope")] string[]? additionalAssemblies = null,
+        [Description("Case sensitive type-name matching (default: false)")] bool caseSensitive = false,
+        [Description("Include non-public methods and types (default: false)")] bool includeNonPublic = false,
+        [Description("Maximum items to return (default: 50)")] int? maxItems = null,
+        [Description("Items to skip (paging)")] int? skip = null,
+        [Description("Continuation token for paging")] string? continuationToken = null,
+        [Description("Response shape. 'summary' (default, token-lean): { declaringType, methodName, signature }. 'full': adds assemblyPath, extendedType.")] string projection = "summary",
+        [Description("Bypass cache for this request")] bool noCache = false)
+    {
+        try
+        {
+            var scope = BuildAndValidateScope(assemblyPath, additionalAssemblies);
+            if (scope.Error != null) return scope.Error;
+
+            var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
+            if (normalizedProjection != "summary" && normalizedProjection != "full")
+                return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
+
+            var scopeKey = string.Join(";", scope.Paths.Select(CacheKeyHelper.FileStamp));
+            var saltSeed = CacheKeyHelper.Build(
+                "reverselookup.extensions.salt",
+                scopeKey, typeName, caseSensitive, includeNonPublic);
+
+            var cacheKey = CacheKeyHelper.Build(
+                "reverselookup.extensions",
+                scopeKey, typeName, caseSensitive, includeNonPublic, maxItems, continuationToken, skip, normalizedProjection);
+
+            return middleware.Execute(cacheKey, () =>
+            {
+                var options = new ReverseLookupOptions(CaseSensitive: caseSensitive, IncludeNonPublic: includeNonPublic);
+                var allHits = reverseLookup.FindExtensionMethodsFor(scope.Paths, typeName, options);
+
+                var defaultPageSize = runtimeOptions.GetMaxItemsForTool("FindExtensionMethodsFor");
+                var pageSize = Math.Max(1, maxItems ?? defaultPageSize);
+                var offset = 0;
+                var salt = TokenHelper.MakeSalt(saltSeed);
+
+                if (!string.IsNullOrWhiteSpace(continuationToken))
+                {
+                    if (!TokenHelper.TryParse(continuationToken!, out offset, out var parsedSalt) || parsedSalt != salt)
+                        return JsonHelpers.Error("InvalidContinuationToken", "The continuation token is invalid or expired.");
+                }
+                else if (skip.HasValue && skip.Value > 0)
+                {
+                    offset = skip.Value;
+                }
+
+                var page = allHits.Skip(offset).Take(pageSize).ToArray();
+                string? nextToken = null;
+                var nextOffset = offset + page.Length;
+                if (nextOffset < allHits.Length) nextToken = TokenHelper.Make(nextOffset, salt);
+
+                object results = normalizedProjection == "summary"
+                    ? page.Select(h => new
+                    {
+                        declaringType = h.DeclaringTypeFullName,
+                        methodName = h.MethodName,
+                        signature = h.Signature
+                    }).ToArray()
+                    : page.Select(h => new
+                    {
+                        declaringType = h.DeclaringTypeFullName,
+                        methodName = h.MethodName,
+                        signature = h.Signature,
+                        assemblyPath = h.AssemblyPath,
+                        extendedType = h.ExtendedTypeFriendlyName
+                    }).ToArray();
+
+                var resultsJson = JsonSerializer.Serialize(results, SerializerOptions);
+                var result = new
+                {
+                    typeName,
+                    scope = scope.Paths,
+                    projection = normalizedProjection,
+                    total = allHits.Length,
+                    count = page.Length,
+                    nextToken,
+                    pagination = PaginationMetadata.Create(allHits.Length, page.Length, nextToken, resultsJson.Length),
+                    results
+                };
+                return JsonHelpers.Envelope("reverselookup.extensions", result);
+            }, noCache);
+        }
+        catch (Exception ex)
+        {
+            return JsonHelpers.Error("InternalError", $"Failed to find extension methods: {ex.Message}");
+        }
+    }
+
+    [McpServerTool]
     [Description("Finds all references to a type across one or more assemblies: base types, implemented interfaces, method returns/parameters, field/property/event types (recurses into generic arguments). Bounded sweep with hardCap to protect against runaway scans; check truncated=true. Returns lean summary by default; projection='full' adds assemblyPath, signature, dedupeKey.")]
     public static string FindReferencesTo(
         IReverseLookupService reverseLookup,

--- a/src/unit-tests/ReverseLookupFixtures.cs
+++ b/src/unit-tests/ReverseLookupFixtures.cs
@@ -40,6 +40,13 @@ public class SnapshotFactory
     public Task<Snapshot<string>> CreateAsync() => Task.FromResult(new Snapshot<string>());
 }
 
+public static class SampleExtensions
+{
+    public static string Shout(this string s) => s.ToUpperInvariant();
+    public static int CountAll<T>(this IEnumerable<T> source) => source.Count();
+    public static T? FirstOrNull<T>(this ISampleEventReader<T> reader) where T : class => reader.Next();
+}
+
 public class EventStore
 {
     public RecordedEvent? LastEvent;

--- a/src/unit-tests/ReverseLookupServiceTests.cs
+++ b/src/unit-tests/ReverseLookupServiceTests.cs
@@ -107,6 +107,64 @@ public class ReverseLookupServiceTests
     }
 
     [Fact]
+    public void FindExtensionMethodsFor_ConcreteType_FindsExtension()
+    {
+        var hits = _svc.FindExtensionMethodsFor(
+            [_testAssemblyPath],
+            "string",
+            _defaultOptions);
+
+        Assert.Contains(hits, h => h.MethodName == nameof(SampleExtensions.Shout)
+            && h.DeclaringTypeFullName == typeof(SampleExtensions).FullName);
+    }
+
+    [Fact]
+    public void FindExtensionMethodsFor_OpenGenericInterface_MatchesExtension()
+    {
+        var hits = _svc.FindExtensionMethodsFor(
+            [_testAssemblyPath],
+            "IEnumerable<>",
+            _defaultOptions);
+
+        Assert.Contains(hits, h => h.MethodName == nameof(SampleExtensions.CountAll));
+    }
+
+    [Fact]
+    public void FindExtensionMethodsFor_OpenGenericCustomInterface_MatchesExtension()
+    {
+        var hits = _svc.FindExtensionMethodsFor(
+            [_testAssemblyPath],
+            "ISampleEventReader<>",
+            _defaultOptions);
+
+        Assert.Contains(hits, h => h.MethodName == nameof(SampleExtensions.FirstOrNull));
+    }
+
+    [Fact]
+    public void FindExtensionMethodsFor_NonExtendedType_ReturnsNoHits()
+    {
+        var hits = _svc.FindExtensionMethodsFor(
+            [_testAssemblyPath],
+            "EventStore",
+            _defaultOptions);
+
+        Assert.Empty(hits);
+    }
+
+    [Fact]
+    public void FindExtensionMethodsFor_PopulatesSignatureAndExtendedType()
+    {
+        var hits = _svc.FindExtensionMethodsFor(
+            [_testAssemblyPath],
+            "string",
+            _defaultOptions);
+
+        var hit = hits.First(h => h.MethodName == nameof(SampleExtensions.Shout));
+        Assert.Contains("Shout", hit.Signature);
+        Assert.Contains("string", hit.ExtendedTypeFriendlyName);
+    }
+
+    [Fact]
     public void FindReferences_EmitsAllReferenceKinds()
     {
         var result = _svc.FindReferences(

--- a/src/unit-tests/ReverseLookupToolsTests.cs
+++ b/src/unit-tests/ReverseLookupToolsTests.cs
@@ -155,6 +155,79 @@ public class ReverseLookupToolsTests
     }
 
     [Fact]
+    public void FindExtensionMethodsFor_Envelope_Summary()
+    {
+        var result = ReverseLookupTools.FindExtensionMethodsFor(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "string", noCache: true);
+
+        Assert.DoesNotContain("\"error\"", result);
+        var doc = JsonDocument.Parse(result);
+        Assert.Equal("reverselookup.extensions", doc.RootElement.GetProperty("kind").GetString());
+
+        var data = doc.RootElement.GetProperty("data");
+        Assert.Equal("summary", data.GetProperty("projection").GetString());
+        Assert.True(data.GetProperty("total").GetInt32() > 0);
+        var first = data.GetProperty("results")[0];
+        Assert.True(first.TryGetProperty("declaringType", out _));
+        Assert.True(first.TryGetProperty("methodName", out _));
+        Assert.True(first.TryGetProperty("signature", out _));
+        Assert.False(first.TryGetProperty("extendedType", out _));
+        Assert.False(first.TryGetProperty("assemblyPath", out _));
+    }
+
+    [Fact]
+    public void FindExtensionMethodsFor_FullIncludesExtraFields()
+    {
+        var result = ReverseLookupTools.FindExtensionMethodsFor(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "string", projection: "full", noCache: true);
+
+        var data = JsonDocument.Parse(result).RootElement.GetProperty("data");
+        Assert.Equal("full", data.GetProperty("projection").GetString());
+        var first = data.GetProperty("results")[0];
+        Assert.True(first.TryGetProperty("extendedType", out _));
+        Assert.True(first.TryGetProperty("assemblyPath", out _));
+    }
+
+    [Fact]
+    public void FindExtensionMethodsFor_OpenGeneric_MatchesExtension()
+    {
+        var result = ReverseLookupTools.FindExtensionMethodsFor(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "IEnumerable<>", noCache: true);
+
+        Assert.DoesNotContain("\"error\"", result);
+        Assert.Contains("CountAll", result);
+    }
+
+    [Fact]
+    public void FindExtensionMethodsFor_ContinuationToken_RoundTrips()
+    {
+        var page1 = ReverseLookupTools.FindExtensionMethodsFor(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "string", maxItems: 1, noCache: true);
+
+        var page1Data = JsonDocument.Parse(page1).RootElement.GetProperty("data");
+        if (page1Data.GetProperty("total").GetInt32() < 2) return;
+
+        var firstMethod = page1Data.GetProperty("results")[0].GetProperty("methodName").GetString();
+        var nextToken = page1Data.GetProperty("nextToken").GetString();
+        Assert.False(string.IsNullOrEmpty(nextToken));
+
+        var page2 = ReverseLookupTools.FindExtensionMethodsFor(
+            _svc, _middleware, _runtimeOptions,
+            _testAssemblyPath, "string",
+            maxItems: 1, continuationToken: nextToken, noCache: true);
+
+        Assert.DoesNotContain("InvalidContinuationToken", page2);
+        var page2Data = JsonDocument.Parse(page2).RootElement.GetProperty("data");
+        Assert.Equal(1, page2Data.GetProperty("count").GetInt32());
+        var secondMethod = page2Data.GetProperty("results")[0].GetProperty("methodName").GetString();
+        Assert.NotEqual(firstMethod, secondMethod);
+    }
+
+    [Fact]
     public void FindReferencesTo_Envelope_IncludesTruncatedFlag()
     {
         var result = ReverseLookupTools.FindReferencesTo(


### PR DESCRIPTION
## Summary

Adds a `FindExtensionMethodsFor` MCP tool (issue #34) that discovers extension methods for a target type — the surface that lives in unrelated static classes (e.g. LINQ over `IEnumerable<T>`), which no existing tool surfaced.

- Scans static classes for methods carrying `ExtensionAttribute` and matches the **first ("this") parameter** against the target via `TypeNameMatcher.Matches` (open-generic forms like `IEnumerable<>` supported).
- New `FindExtensionMethodsFor` on `IReverseLookupService` + `ReverseLookupService`, reusing the existing `ScanInParallel` / `GetScannableTypes` / `FormatMethodSignature` plumbing.
- New tool in `ReverseLookupTools`, copied from the `FindMethodsReturning` scaffolding: `assemblyPath` + `additionalAssemblies` scope, pagination/continuation tokens, `FileStamp` cache keys, lean `summary` projection (`{ declaringType, methodName, signature }`) with `full` adding `extendedType`/`assemblyPath`. Envelope kind `reverselookup.extensions`.
- New `ExtensionMethodHit` contract.
- Updated tool counts in `CLAUDE.md` (32→33; Reverse Lookup 3→4).

## Test plan

- New fixture `SampleExtensions` (string, open-generic `IEnumerable<T>`, custom `ISampleEventReader<T>`).
- 5 service tests: concrete-type match, open-generic interface match (built-in + custom), no-hit for a non-extended type, signature/extended-type population.
- 4 tool tests: summary envelope shape, full projection extra fields, open-generic match, continuation-token round-trip.
- `dotnet build` clean (warnings-as-errors); full unit suite **155/155 passing** on net8.0 and net10.0. (net9.0 runtime not installed locally — environment gap, CI covers it.)

Closes #34.