### PR TITLE
feat: add GetAssemblyInfo tool for assembly-level metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,14 +32,14 @@ This is a comprehensive .NET MCP (Model Context Protocol) server called "Sherloc
 This MCP server provides LLMs with comprehensive .NET reflection capabilities through several key architectural principles:
 
 ### Assembly-First Discovery
-Since the MCP server runs as a separate process, it cannot access the client's loaded assemblies. Instead, it provides 33 specialized tools for clients to:
+Since the MCP server runs as a separate process, it cannot access the client's loaded assemblies. Instead, it provides 34 specialized tools for clients to:
 1. **Discover assemblies** using multiple strategies (project analysis, class name search, file system scanning)
 2. **Load and analyze** specific assemblies by path with efficient caching
 3. **Deep introspection** of types, members, attributes, and XML documentation
 4. **Performance optimization** through pagination, streaming, and response size validation
 
-### Tool Categories (33 Available)
-- **Assembly Discovery & Analysis** (3 tools): `AnalyzeAssembly`, `FindAssemblyByClassName`, `FindAssemblyByFileName`
+### Tool Categories (34 Available)
+- **Assembly Discovery & Analysis** (4 tools): `AnalyzeAssembly`, `GetAssemblyInfo`, `FindAssemblyByClassName`, `FindAssemblyByFileName`
 - **Type Introspection** (7 tools): `GetTypesFromAssembly`, `GetTypeInfo`, `GetTypeHierarchy`, etc.
 - **Member Analysis** (8 tools): `GetTypeMethods`, `GetTypeProperties`, `GetAllTypeMembers`, etc.
 - **Reverse Lookup** (4 tools): `FindImplementationsOf`, `FindMethodsReturning`, `FindExtensionMethodsFor`, `FindReferencesTo`

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Use GetTypeMethods on /abs/path/MyLib.dll, type MyNamespace.MyType, sortBy name,
 
 ### Assembly Discovery & Analysis
 - **`AnalyzeAssembly`**: Complete assembly overview with public types and metadata
+- **`GetAssemblyInfo`**: Assembly-level metadata — identity/version, target framework, and referenced assemblies (`projection=full` adds all assembly attributes)
 - **`FindAssemblyByClassName`**: Locate assemblies containing specific class names
 - **`FindAssemblyByFileName`**: Find assemblies by file name in common build paths
 

--- a/src/server/Shared/ResponseSizeHelper.cs
+++ b/src/server/Shared/ResponseSizeHelper.cs
@@ -127,6 +127,11 @@ public static class ResponseSizeHelper
                 new[] { "GetTypeMethods", "GetTypeProperties", "GetTypeFields" },
                 new { maxItems = 15 }
             ),
+            "GetAssemblyInfo" => (
+                "Use the lean projection to avoid returning every assembly attribute.",
+                Array.Empty<string>(),
+                new { projection = "summary" }
+            ),
             _ => (
                 "Use pagination parameters to retrieve data in smaller chunks.",
                 Array.Empty<string>(),

--- a/src/server/Tools/ReflectionTools.cs
+++ b/src/server/Tools/ReflectionTools.cs
@@ -102,6 +102,74 @@ public static class ReflectionTools
         }
     }
 
+    [McpServerTool]
+    [Description("Gets assembly-level metadata: identity/version, target framework, and referenced assemblies. Lightweight orientation tool — call before deep type analysis. Use projection='full' for all assembly-level attributes structurally.")]
+    public static string GetAssemblyInfo(
+        IInspectionContextProvider contexts,
+        [Description("Path to the .NET assembly file (.dll or .exe)")] string assemblyPath,
+        [Description("Detail level: 'summary' (default, lean) or 'full' (adds all assembly attributes)")] string projection = "summary")
+    {
+        try
+        {
+            if (!File.Exists(assemblyPath))
+                return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
+
+            using var lease = contexts.Acquire(assemblyPath);
+            var assembly = lease.Assembly;
+            var name = assembly.GetName();
+
+            var referencedAssemblies = assembly.GetReferencedAssemblies()
+                .Select(r => $"{r.Name}@{r.Version}")
+                .OrderBy(r => r, StringComparer.Ordinal)
+                .ToArray();
+
+            var isFull = string.Equals(projection, "full", StringComparison.OrdinalIgnoreCase);
+
+            object result = isFull
+                ? new
+                {
+                    projection = "full",
+                    name = name.Name,
+                    version = name.Version?.ToString(),
+                    fullName = assembly.FullName,
+                    location = assembly.Location,
+                    targetFramework = ReadTargetFramework(assembly),
+                    referencedAssemblies,
+                    attributes = assembly.GetCustomAttributesData().Select(AttributeUtils.Convert).ToArray()
+                }
+                : new
+                {
+                    projection = "summary",
+                    name = name.Name,
+                    version = name.Version?.ToString(),
+                    fullName = assembly.FullName,
+                    location = assembly.Location,
+                    targetFramework = ReadTargetFramework(assembly),
+                    referencedAssemblies
+                };
+
+            return JsonHelpers.Envelope("reflection.assemblyInfo", result);
+        }
+        catch (Exception ex)
+        {
+            return JsonHelpers.Error("InternalError", $"Failed to get assembly info: {ex.Message}");
+        }
+    }
+
+    private static string? ReadTargetFramework(Assembly assembly)
+    {
+        try
+        {
+            var attr = assembly.GetCustomAttributesData()
+                .FirstOrDefault(a => a.AttributeType.FullName == "System.Runtime.Versioning.TargetFrameworkAttribute");
+            return attr?.ConstructorArguments.Count > 0 ? attr.ConstructorArguments[0].Value as string : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     private static object? SafeRawDefault(ParameterInfo p)
     {
         try { return p.RawDefaultValue; }

--- a/src/server/Tools/ReflectionTools.cs
+++ b/src/server/Tools/ReflectionTools.cs
@@ -114,6 +114,10 @@ public static class ReflectionTools
             if (!File.Exists(assemblyPath))
                 return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
 
+            var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
+            if (normalizedProjection != "summary" && normalizedProjection != "full")
+                return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
+
             using var lease = contexts.Acquire(assemblyPath);
             var assembly = lease.Assembly;
             var name = assembly.GetName();
@@ -123,7 +127,7 @@ public static class ReflectionTools
                 .OrderBy(r => r, StringComparer.Ordinal)
                 .ToArray();
 
-            var isFull = string.Equals(projection, "full", StringComparison.OrdinalIgnoreCase);
+            var isFull = normalizedProjection == "full";
 
             object result = isFull
                 ? new
@@ -147,6 +151,10 @@ public static class ReflectionTools
                     targetFramework = ReadTargetFramework(assembly),
                     referencedAssemblies
                 };
+
+            var sizeValidationError = ResponseSizeHelper.ValidateResponseSize(result, "GetAssemblyInfo");
+            if (sizeValidationError != null)
+                return sizeValidationError;
 
             return JsonHelpers.Envelope("reflection.assemblyInfo", result);
         }

--- a/src/unit-tests/ReflectionToolsTests.cs
+++ b/src/unit-tests/ReflectionToolsTests.cs
@@ -1,0 +1,54 @@
+using System.Reflection;
+using System.Text.Json;
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Inspection;
+using Sherlock.MCP.Server.Tools;
+
+namespace Sherlock.MCP.Tests;
+
+public class ReflectionToolsTests : IDisposable
+{
+    private readonly SharedInspectionContextProvider _contexts = new(new RuntimeOptions());
+    private readonly string _testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+    public void Dispose() => _contexts.Dispose();
+
+    [Fact]
+    public void GetAssemblyInfo_Summary_EnvelopeAndShape()
+    {
+        var result = ReflectionTools.GetAssemblyInfo(_contexts, _testAssemblyPath);
+
+        Assert.DoesNotContain("\"error\"", result);
+        var doc = JsonDocument.Parse(result);
+        Assert.Equal("reflection.assemblyInfo", doc.RootElement.GetProperty("kind").GetString());
+
+        var data = doc.RootElement.GetProperty("data");
+        Assert.Equal("summary", data.GetProperty("projection").GetString());
+        Assert.False(string.IsNullOrEmpty(data.GetProperty("name").GetString()));
+        Assert.False(string.IsNullOrEmpty(data.GetProperty("version").GetString()));
+        Assert.False(string.IsNullOrEmpty(data.GetProperty("targetFramework").GetString()));
+        Assert.True(data.GetProperty("referencedAssemblies").GetArrayLength() > 0);
+        Assert.False(data.TryGetProperty("attributes", out _), "Summary should not include attributes");
+    }
+
+    [Fact]
+    public void GetAssemblyInfo_Full_IncludesAttributes()
+    {
+        var result = ReflectionTools.GetAssemblyInfo(_contexts, _testAssemblyPath, projection: "full");
+
+        Assert.DoesNotContain("\"error\"", result);
+        var data = JsonDocument.Parse(result).RootElement.GetProperty("data");
+        Assert.Equal("full", data.GetProperty("projection").GetString());
+        Assert.True(data.GetProperty("attributes").GetArrayLength() > 0);
+    }
+
+    [Fact]
+    public void GetAssemblyInfo_MissingFile_ReturnsAssemblyNotFound()
+    {
+        var result = ReflectionTools.GetAssemblyInfo(_contexts, "/no/such/assembly.dll");
+
+        var doc = JsonDocument.Parse(result);
+        Assert.Equal("error", doc.RootElement.GetProperty("kind").GetString());
+        Assert.Equal("AssemblyNotFound", doc.RootElement.GetProperty("code").GetString());
+    }
+}

--- a/src/unit-tests/ReflectionToolsTests.cs
+++ b/src/unit-tests/ReflectionToolsTests.cs
@@ -43,6 +43,27 @@ public class ReflectionToolsTests : IDisposable
     }
 
     [Fact]
+    public void GetAssemblyInfo_InvalidProjection_ReturnsInvalidProjection()
+    {
+        var result = ReflectionTools.GetAssemblyInfo(_contexts, _testAssemblyPath, projection: "verbose");
+
+        var doc = JsonDocument.Parse(result);
+        Assert.Equal("error", doc.RootElement.GetProperty("kind").GetString());
+        Assert.Equal("InvalidProjection", doc.RootElement.GetProperty("code").GetString());
+    }
+
+    [Fact]
+    public void GetAssemblyInfo_ProjectionIsNormalized()
+    {
+        var result = ReflectionTools.GetAssemblyInfo(_contexts, _testAssemblyPath, projection: "  FULL  ");
+
+        Assert.DoesNotContain("\"error\"", result);
+        var data = JsonDocument.Parse(result).RootElement.GetProperty("data");
+        Assert.Equal("full", data.GetProperty("projection").GetString());
+        Assert.True(data.GetProperty("attributes").GetArrayLength() > 0);
+    }
+
+    [Fact]
     public void GetAssemblyInfo_MissingFile_ReturnsAssemblyNotFound()
     {
         var result = ReflectionTools.GetAssemblyInfo(_contexts, "/no/such/assembly.dll");


### PR DESCRIPTION
## Summary

Adds a new `GetAssemblyInfo` MCP tool (issue #36) exposing assembly-level metadata that previously had no tool: identity/version, target framework, `InternalsVisibleTo`/other assembly attributes, and referenced assemblies. This is a cheap, high-frequency orientation call agents can make before deeper type analysis — no more guessing the TFM or scraping the `.csproj`.

- New `GetAssemblyInfo(contexts, assemblyPath, projection="summary")` in `ReflectionTools`, following the sibling `AnalyzeAssembly` shape (`IInspectionContextProvider` lease, `JsonHelpers` envelope/error).
- `summary` (default, lean): `name`, `version`, `fullName`, `location`, `targetFramework`, `referencedAssemblies` (`name@version`).
- `full`: adds all assembly attributes structurally, reusing existing `AttributeUtils.Convert`.
- Target framework read via metadata-safe `GetCustomAttributesData()` so it works in the metadata-only load context.
- Docs updated: tool count 33 → 34 (`CLAUDE.md`), Tools Overview bullet (`README.md`).

## Test plan

- New `ReflectionToolsTests.cs` with 3 tests: summary shape/envelope, full-includes-attributes, missing-file → `AssemblyNotFound`.
- `dotnet build` clean (warnings-as-errors enforced).
- Full unit suite green: 158/158 on net10.0; new tests pass on net8.0 and net10.0 (net9.0 runtime not installed locally).

Closes #36