### PR TITLE
feat: add IL call analysis (GetMethodCalls tool + analysisDepth=il)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,17 +32,17 @@ This is a comprehensive .NET MCP (Model Context Protocol) server called "Sherloc
 This MCP server provides LLMs with comprehensive .NET reflection capabilities through several key architectural principles:
 
 ### Assembly-First Discovery
-Since the MCP server runs as a separate process, it cannot access the client's loaded assemblies. Instead, it provides 34 specialized tools for clients to:
+Since the MCP server runs as a separate process, it cannot access the client's loaded assemblies. Instead, it provides 35 specialized tools for clients to:
 1. **Discover assemblies** using multiple strategies (project analysis, class name search, file system scanning)
 2. **Load and analyze** specific assemblies by path with efficient caching
 3. **Deep introspection** of types, members, attributes, and XML documentation
 4. **Performance optimization** through pagination, streaming, and response size validation
 
-### Tool Categories (34 Available)
+### Tool Categories (35 Available)
 - **Assembly Discovery & Analysis** (4 tools): `AnalyzeAssembly`, `GetAssemblyInfo`, `FindAssemblyByClassName`, `FindAssemblyByFileName`
 - **Type Introspection** (7 tools): `GetTypesFromAssembly`, `GetTypeInfo`, `GetTypeHierarchy`, etc.
 - **Member Analysis** (8 tools): `GetTypeMethods`, `GetTypeProperties`, `GetAllTypeMembers`, etc.
-- **Reverse Lookup** (4 tools): `FindImplementationsOf`, `FindMethodsReturning`, `FindExtensionMethodsFor`, `FindReferencesTo`
+- **Reverse Lookup & IL Analysis** (5 tools): `FindImplementationsOf`, `FindMethodsReturning`, `FindExtensionMethodsFor`, `FindReferencesTo` (supports `analysisDepth='il'` for inbound callers), `GetMethodCalls` (outbound IL call/field analysis)
 - **Attributes & Metadata** (2 tools): `GetMemberAttributes`, `GetParameterAttributes`
 - **XML Documentation** (2 tools): `GetXmlDocsForType`, `GetXmlDocsForMember`
 - **Project Analysis** (5 tools): `AnalyzeSolution`, `AnalyzeProject`, `ResolvePackageReferences`, etc.

--- a/src/runtime/Contracts/Il/MethodCallInfo.cs
+++ b/src/runtime/Contracts/Il/MethodCallInfo.cs
@@ -1,0 +1,11 @@
+namespace Sherlock.MCP.Runtime.Contracts.Il;
+
+public record MethodCallInfo(
+    string Target,
+    string Kind,
+    string SourceMethod);
+
+public record FieldAccessInfo(
+    string Target,
+    string Access,
+    string SourceMethod);

--- a/src/runtime/Contracts/Il/MethodCallsResult.cs
+++ b/src/runtime/Contracts/Il/MethodCallsResult.cs
@@ -1,0 +1,20 @@
+namespace Sherlock.MCP.Runtime.Contracts.Il;
+
+public record MethodCallsResult(
+    string DeclaringTypeFullName,
+    string MethodName,
+    int MatchedOverloads,
+    bool AnyBodyless,
+    MethodCallInfo[] Calls,
+    FieldAccessInfo[] FieldAccesses);
+
+public record InboundCallHit(
+    string AssemblyPath,
+    string CallerTypeFullName,
+    string CallerMethod,
+    string ReferenceKind,
+    string TargetMember);
+
+public record IlAnalysisOptions(
+    bool CaseSensitive = false,
+    bool IncludeNonPublic = false);

--- a/src/runtime/IIlAnalysisService.cs
+++ b/src/runtime/IIlAnalysisService.cs
@@ -1,0 +1,11 @@
+using Sherlock.MCP.Runtime.Contracts.Il;
+using Sherlock.MCP.Runtime.Contracts.ReverseLookup;
+
+namespace Sherlock.MCP.Runtime;
+
+public interface IIlAnalysisService
+{
+    MethodCallsResult? GetMethodCalls(string assemblyPath, string typeName, string methodName, IlAnalysisOptions options);
+
+    InboundCallHit[] FindInboundCallers(string[] assemblyPaths, string typeName, ReverseLookupOptions options);
+}

--- a/src/runtime/Il/IlInstructionReader.cs
+++ b/src/runtime/Il/IlInstructionReader.cs
@@ -1,0 +1,121 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Sherlock.MCP.Runtime.Il;
+
+internal enum IlRefKind
+{
+    None,
+    Call,
+    CallVirt,
+    NewObj,
+    LdFtn,
+    LdVirtFtn,
+    LdFld,
+    LdsFld,
+    StFld,
+    StsFld
+}
+
+internal readonly record struct IlTokenRef(IlRefKind Kind, int Token);
+
+// Walks raw IL bytes and yields the metadata-token operands of call/field instructions.
+// The operand-size table is derived from System.Reflection.Emit.OpCodes so every opcode width is
+// transcription-free: a wrong width would silently desync the instruction pointer.
+internal static class IlInstructionReader
+{
+    private const int SwitchOperand = -2;
+
+    private static readonly Dictionary<int, int> OperandWidths = BuildOperandWidths();
+
+    internal static IEnumerable<IlTokenRef> ReadTokenInstructions(byte[]? il)
+    {
+        if (il is null || il.Length == 0) yield break;
+
+        var ip = 0;
+        var len = il.Length;
+
+        while (ip < len)
+        {
+            int opcode = il[ip++];
+            if (opcode == 0xFE)
+            {
+                if (ip >= len) yield break;
+                opcode = 0xFE00 | il[ip++];
+            }
+
+            if (!OperandWidths.TryGetValue(opcode, out var width))
+                yield break;
+
+            if (width == SwitchOperand)
+            {
+                if (ip + 4 > len) yield break;
+                var count = ReadInt32(il, ip);
+                var next = (long)ip + 4 + ((long)count * 4);
+                if (count < 0 || next > len) yield break;
+                ip = (int)next;
+                continue;
+            }
+
+            var kind = Classify(opcode);
+            if (kind != IlRefKind.None)
+            {
+                if (ip + 4 > len) yield break;
+                yield return new IlTokenRef(kind, ReadInt32(il, ip));
+            }
+
+            if (ip + width > len) yield break;
+            ip += width;
+        }
+    }
+
+    private static IlRefKind Classify(int opcode) => opcode switch
+    {
+        0x28 => IlRefKind.Call,
+        0x6F => IlRefKind.CallVirt,
+        0x73 => IlRefKind.NewObj,
+        0xFE06 => IlRefKind.LdFtn,
+        0xFE07 => IlRefKind.LdVirtFtn,
+        0x7B => IlRefKind.LdFld,
+        0x7E => IlRefKind.LdsFld,
+        0x7D => IlRefKind.StFld,
+        0x80 => IlRefKind.StsFld,
+        _ => IlRefKind.None
+    };
+
+    private static int ReadInt32(byte[] il, int offset) =>
+        il[offset] | (il[offset + 1] << 8) | (il[offset + 2] << 16) | (il[offset + 3] << 24);
+
+    private static Dictionary<int, int> BuildOperandWidths()
+    {
+        var map = new Dictionary<int, int>();
+        foreach (var field in typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (field.GetValue(null) is not OpCode op) continue;
+            map[(ushort)op.Value] = WidthOf(op.OperandType);
+        }
+        return map;
+    }
+
+    private static int WidthOf(OperandType operandType) => operandType switch
+    {
+        OperandType.InlineNone => 0,
+        OperandType.ShortInlineBrTarget => 1,
+        OperandType.ShortInlineI => 1,
+        OperandType.ShortInlineVar => 1,
+        OperandType.InlineVar => 2,
+        OperandType.ShortInlineR => 4,
+        OperandType.InlineBrTarget => 4,
+        OperandType.InlineField => 4,
+        OperandType.InlineI => 4,
+        OperandType.InlineMethod => 4,
+        OperandType.InlineSig => 4,
+        OperandType.InlineString => 4,
+        OperandType.InlineTok => 4,
+        OperandType.InlineType => 4,
+        OperandType.InlineI8 => 8,
+        OperandType.InlineR => 8,
+        OperandType.InlineSwitch => SwitchOperand,
+        _ => 0
+    };
+}

--- a/src/runtime/Il/MetadataTokenResolver.cs
+++ b/src/runtime/Il/MetadataTokenResolver.cs
@@ -1,0 +1,161 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace Sherlock.MCP.Runtime.Il;
+
+internal enum MemberRefKind
+{
+    Method,
+    Field
+}
+
+internal readonly record struct ResolvedMember(string DeclaringType, string MemberName, MemberRefKind Kind)
+{
+    public string Display => string.IsNullOrEmpty(DeclaringType) ? MemberName : $"{DeclaringType}.{MemberName}";
+}
+
+// Resolves an IL metadata-token operand to a "Namespace.Type.Member" display string.
+// Pure metadata: no type-system loading. Declaring-type names use the same format as Type.FullName
+// (namespace + '.' name, '+' for nested types, backtick arity preserved) so callers can compare
+// against MLC Type.FullName values directly.
+internal sealed class MetadataTokenResolver
+{
+    private readonly MetadataReader _md;
+    private readonly StringSignatureTypeProvider _provider;
+
+    public MetadataTokenResolver(MetadataReader md)
+    {
+        _md = md;
+        _provider = new StringSignatureTypeProvider(md);
+    }
+
+    public ResolvedMember? Resolve(int token)
+    {
+        EntityHandle handle;
+        try { handle = MetadataTokens.EntityHandle(token); }
+        catch (ArgumentException) { return null; }
+        if (handle.IsNil) return null;
+
+        switch (handle.Kind)
+        {
+            case HandleKind.MethodDefinition:
+            {
+                var def = _md.GetMethodDefinition((MethodDefinitionHandle)handle);
+                return new ResolvedMember(TypeDefName(def.GetDeclaringType()), _md.GetString(def.Name), MemberRefKind.Method);
+            }
+            case HandleKind.FieldDefinition:
+            {
+                var def = _md.GetFieldDefinition((FieldDefinitionHandle)handle);
+                return new ResolvedMember(TypeDefName(def.GetDeclaringType()), _md.GetString(def.Name), MemberRefKind.Field);
+            }
+            case HandleKind.MemberReference:
+            {
+                var mr = _md.GetMemberReference((MemberReferenceHandle)handle);
+                var kind = mr.GetKind() == MemberReferenceKind.Field ? MemberRefKind.Field : MemberRefKind.Method;
+                return new ResolvedMember(ParentName(mr.Parent), _md.GetString(mr.Name), kind);
+            }
+            case HandleKind.MethodSpecification:
+            {
+                var spec = _md.GetMethodSpecification((MethodSpecificationHandle)handle);
+                return Resolve(MetadataTokens.GetToken(spec.Method));
+            }
+            default:
+                return null;
+        }
+    }
+
+    public string TypeDefName(TypeDefinitionHandle handle) => _provider.GetTypeFromDefinition(_md, handle, 0);
+
+    private string ParentName(EntityHandle parent)
+    {
+        if (parent.IsNil) return string.Empty;
+        switch (parent.Kind)
+        {
+            case HandleKind.TypeDefinition:
+                return _provider.GetTypeFromDefinition(_md, (TypeDefinitionHandle)parent, 0);
+            case HandleKind.TypeReference:
+                return _provider.GetTypeFromReference(_md, (TypeReferenceHandle)parent, 0);
+            case HandleKind.TypeSpecification:
+                try { return _md.GetTypeSpecification((TypeSpecificationHandle)parent).DecodeSignature(_provider, null); }
+                catch (BadImageFormatException) { return "<generic>"; }
+            case HandleKind.MethodDefinition:
+            {
+                var def = _md.GetMethodDefinition((MethodDefinitionHandle)parent);
+                return _provider.GetTypeFromDefinition(_md, def.GetDeclaringType(), 0);
+            }
+            default:
+                return "<unknown>";
+        }
+    }
+}
+
+// Produces type names as strings while decoding metadata signatures. Only the declaring-type
+// portion is needed for call resolution, so generic instantiations collapse to the open
+// generic-type-definition name (e.g. System.Collections.Generic.List`1).
+internal sealed class StringSignatureTypeProvider : ISignatureTypeProvider<string, object?>
+{
+    private readonly MetadataReader _md;
+
+    public StringSignatureTypeProvider(MetadataReader md) => _md = md;
+
+    public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+    {
+        var td = reader.GetTypeDefinition(handle);
+        var name = reader.GetString(td.Name);
+        var declaring = td.GetDeclaringType();
+        if (!declaring.IsNil)
+            return $"{GetTypeFromDefinition(reader, declaring, 0)}+{name}";
+        var ns = reader.GetString(td.Namespace);
+        return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+    }
+
+    public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+    {
+        var tr = reader.GetTypeReference(handle);
+        var name = reader.GetString(tr.Name);
+        var scope = tr.ResolutionScope;
+        if (!scope.IsNil && scope.Kind == HandleKind.TypeReference)
+            return $"{GetTypeFromReference(reader, (TypeReferenceHandle)scope, 0)}+{name}";
+        var ns = reader.GetString(tr.Namespace);
+        return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+    }
+
+    public string GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind) =>
+        reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+
+    public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments) => genericType;
+
+    public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode switch
+    {
+        PrimitiveTypeCode.Boolean => "System.Boolean",
+        PrimitiveTypeCode.Byte => "System.Byte",
+        PrimitiveTypeCode.SByte => "System.SByte",
+        PrimitiveTypeCode.Char => "System.Char",
+        PrimitiveTypeCode.Int16 => "System.Int16",
+        PrimitiveTypeCode.UInt16 => "System.UInt16",
+        PrimitiveTypeCode.Int32 => "System.Int32",
+        PrimitiveTypeCode.UInt32 => "System.UInt32",
+        PrimitiveTypeCode.Int64 => "System.Int64",
+        PrimitiveTypeCode.UInt64 => "System.UInt64",
+        PrimitiveTypeCode.Single => "System.Single",
+        PrimitiveTypeCode.Double => "System.Double",
+        PrimitiveTypeCode.IntPtr => "System.IntPtr",
+        PrimitiveTypeCode.UIntPtr => "System.UIntPtr",
+        PrimitiveTypeCode.Object => "System.Object",
+        PrimitiveTypeCode.String => "System.String",
+        PrimitiveTypeCode.Void => "System.Void",
+        PrimitiveTypeCode.TypedReference => "System.TypedReference",
+        _ => "System.Object"
+    };
+
+    public string GetSZArrayType(string elementType) => $"{elementType}[]";
+    public string GetArrayType(string elementType, ArrayShape shape) => $"{elementType}[]";
+    public string GetByReferenceType(string elementType) => $"{elementType}&";
+    public string GetPointerType(string elementType) => $"{elementType}*";
+    public string GetPinnedType(string elementType) => elementType;
+    public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
+    public string GetGenericMethodParameter(object? genericContext, int index) => $"!!{index}";
+    public string GetGenericTypeParameter(object? genericContext, int index) => $"!{index}";
+    public string GetFunctionPointerType(MethodSignature<string> signature) => "System.IntPtr";
+}

--- a/src/runtime/Il/MetadataTypeNameMatcher.cs
+++ b/src/runtime/Il/MetadataTypeNameMatcher.cs
@@ -1,0 +1,108 @@
+namespace Sherlock.MCP.Runtime.Il;
+
+// String-level type-name matcher for resolved metadata names (e.g. "System.Console",
+// "System.Collections.Generic.List`1", "Outer+Nested"). Mirrors TypeNameMatcher's flexibility
+// (simple/full name, backtick arity, built-in aliases) but works on the strings produced by
+// MetadataTokenResolver, so it matches external types not loadable in the inspection context.
+internal static class MetadataTypeNameMatcher
+{
+    private static readonly Dictionary<string, string> BuiltInToClrName = new(StringComparer.Ordinal)
+    {
+        ["bool"] = "Boolean",
+        ["byte"] = "Byte",
+        ["sbyte"] = "SByte",
+        ["char"] = "Char",
+        ["decimal"] = "Decimal",
+        ["double"] = "Double",
+        ["float"] = "Single",
+        ["int"] = "Int32",
+        ["uint"] = "UInt32",
+        ["long"] = "Int64",
+        ["ulong"] = "UInt64",
+        ["object"] = "Object",
+        ["short"] = "Int16",
+        ["ushort"] = "UInt16",
+        ["string"] = "String",
+        ["void"] = "Void",
+        ["nint"] = "IntPtr",
+        ["nuint"] = "UIntPtr"
+    };
+
+    public static bool Matches(string metadataDeclaringType, string userSuppliedName, bool caseSensitive)
+    {
+        if (string.IsNullOrEmpty(metadataDeclaringType)) return false;
+        if (string.IsNullOrWhiteSpace(userSuppliedName)) return false;
+
+        var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
+        var full = metadataDeclaringType.Replace('+', '.');
+        var fullStripped = StripArity(full);
+
+        foreach (var variant in ExpandUserNameVariants(userSuppliedName, caseSensitive))
+        {
+            if (string.IsNullOrEmpty(variant)) continue;
+            if (string.Equals(full, variant, comparison)) return true;
+            if (string.Equals(fullStripped, variant, comparison)) return true;
+            foreach (var suffix in DottedSuffixes(fullStripped))
+                if (string.Equals(suffix, variant, comparison)) return true;
+        }
+        return false;
+    }
+
+    private static IEnumerable<string> ExpandUserNameVariants(string userSuppliedName, bool caseSensitive)
+    {
+        var s = userSuppliedName.Trim();
+
+        var commaIdx = s.IndexOf(',');
+        if (commaIdx >= 0) s = s.Substring(0, commaIdx).Trim();
+
+        s = s.Replace('+', '.');
+
+        yield return s;
+        var stripped = StripArity(s);
+        yield return stripped;
+
+        if (TryGetBuiltInClrName(stripped, caseSensitive, out var clr))
+        {
+            yield return clr;
+            yield return "System." + clr;
+        }
+    }
+
+    private static bool TryGetBuiltInClrName(string alias, bool caseSensitive, out string clrName)
+    {
+        if (caseSensitive)
+            return BuiltInToClrName.TryGetValue(alias, out clrName!);
+
+        foreach (var kvp in BuiltInToClrName)
+        {
+            if (string.Equals(kvp.Key, alias, StringComparison.OrdinalIgnoreCase))
+            {
+                clrName = kvp.Value;
+                return true;
+            }
+        }
+        clrName = string.Empty;
+        return false;
+    }
+
+    private static IEnumerable<string> DottedSuffixes(string dotted)
+    {
+        var idx = 0;
+        while (true)
+        {
+            var nextDot = dotted.IndexOf('.', idx);
+            if (nextDot < 0) yield break;
+            var suffix = dotted.Substring(nextDot + 1);
+            if (suffix.Length > 0) yield return suffix;
+            idx = nextDot + 1;
+        }
+    }
+
+    private static string StripArity(string name)
+    {
+        var backtickIdx = name.IndexOf('`');
+        if (backtickIdx >= 0) name = name.Substring(0, backtickIdx);
+        return name;
+    }
+}

--- a/src/runtime/IlAnalysisService.cs
+++ b/src/runtime/IlAnalysisService.cs
@@ -1,0 +1,294 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using Sherlock.MCP.Runtime.Contracts.Il;
+using Sherlock.MCP.Runtime.Contracts.ReverseLookup;
+using Sherlock.MCP.Runtime.Il;
+using Sherlock.MCP.Runtime.Inspection;
+
+namespace Sherlock.MCP.Runtime;
+
+public class IlAnalysisService : IIlAnalysisService
+{
+    private readonly IInspectionContextProvider _contexts;
+
+    public IlAnalysisService() : this(new SharedInspectionContextProvider(new RuntimeOptions()))
+    {
+    }
+
+    public IlAnalysisService(IInspectionContextProvider contexts) => _contexts = contexts;
+
+    public MethodCallsResult? GetMethodCalls(string assemblyPath, string typeName, string methodName, IlAnalysisOptions options)
+    {
+        if (!File.Exists(assemblyPath)) return null;
+
+        var flags = BuildMemberFlags(options.IncludeNonPublic);
+        Type? targetType = null;
+        var targets = new List<MethodBase>();
+
+        using (var lease = _contexts.Acquire(assemblyPath))
+        {
+            foreach (var candidate in SafeGetTypes(lease.Context))
+            {
+                if (!TypeNameMatcher.Matches(candidate, typeName, options.CaseSensitive)) continue;
+
+                targetType = candidate;
+                foreach (var method in SafeGetMethods(candidate, flags))
+                {
+                    if (NameEquals(method.Name, methodName, options.CaseSensitive)) targets.Add(method);
+                }
+                if (IsConstructorName(methodName))
+                {
+                    foreach (var ctor in SafeGetConstructors(candidate, flags)) targets.Add(ctor);
+                }
+                break;
+            }
+        }
+
+        if (targetType == null || targets.Count == 0) return null;
+
+        var declaringFullName = TypeNameFormatter.FriendlyFullName(targetType);
+        var calls = new List<MethodCallInfo>();
+        var fieldAccesses = new List<FieldAccessInfo>();
+        var anyBodyless = false;
+
+        using (var stream = File.OpenRead(assemblyPath))
+        using (var pe = new PEReader(stream))
+        {
+            if (!pe.HasMetadata) return null;
+            var md = pe.GetMetadataReader();
+            var resolver = new MetadataTokenResolver(md);
+
+            foreach (var method in targets)
+            {
+                var il = TryGetMethodBody(pe, md, method.MetadataToken, out var hadBody);
+                if (!hadBody)
+                {
+                    anyBodyless = true;
+                    continue;
+                }
+
+                var sourceMethod = FormatSignature(method);
+                foreach (var tokenRef in IlInstructionReader.ReadTokenInstructions(il))
+                {
+                    var resolved = resolver.Resolve(tokenRef.Token);
+                    if (resolved == null) continue;
+
+                    if (IsFieldAccess(tokenRef.Kind))
+                        fieldAccesses.Add(new FieldAccessInfo(resolved.Value.Display, FieldAccessName(tokenRef.Kind), sourceMethod));
+                    else
+                        calls.Add(new MethodCallInfo(resolved.Value.Display, CallKindName(tokenRef.Kind), sourceMethod));
+                }
+            }
+        }
+
+        var distinctCalls = calls
+            .GroupBy(c => (c.Target, c.Kind, c.SourceMethod))
+            .Select(g => g.First())
+            .OrderBy(c => c.Target, StringComparer.Ordinal)
+            .ThenBy(c => c.Kind, StringComparer.Ordinal)
+            .ThenBy(c => c.SourceMethod, StringComparer.Ordinal)
+            .ToArray();
+
+        var distinctFields = fieldAccesses
+            .GroupBy(f => (f.Target, f.Access, f.SourceMethod))
+            .Select(g => g.First())
+            .OrderBy(f => f.Target, StringComparer.Ordinal)
+            .ThenBy(f => f.Access, StringComparer.Ordinal)
+            .ThenBy(f => f.SourceMethod, StringComparer.Ordinal)
+            .ToArray();
+
+        return new MethodCallsResult(declaringFullName, methodName, targets.Count, anyBodyless, distinctCalls, distinctFields);
+    }
+
+    public InboundCallHit[] FindInboundCallers(string[] assemblyPaths, string typeName, ReverseLookupOptions options)
+    {
+        var hits = new ConcurrentBag<InboundCallHit>();
+        var cap = Math.Max(1, options.HardCap);
+        var reserved = 0;
+        var truncated = 0;
+
+        bool TryAdd(InboundCallHit hit)
+        {
+            if (Interlocked.Increment(ref reserved) > cap)
+            {
+                Interlocked.Exchange(ref truncated, 1);
+                return false;
+            }
+            hits.Add(hit);
+            return true;
+        }
+
+        var paths = assemblyPaths.Where(File.Exists).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        Parallel.ForEach(
+            paths,
+            new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
+            path =>
+            {
+                if (Volatile.Read(ref truncated) == 1) return;
+                ScanAssemblyForCallers(path, typeName, options, TryAdd, () => Volatile.Read(ref truncated) == 1);
+            });
+
+        return hits
+            .OrderBy(h => h.AssemblyPath, StringComparer.Ordinal)
+            .ThenBy(h => h.CallerTypeFullName, StringComparer.Ordinal)
+            .ThenBy(h => h.CallerMethod, StringComparer.Ordinal)
+            .ThenBy(h => h.ReferenceKind, StringComparer.Ordinal)
+            .ThenBy(h => h.TargetMember, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static void ScanAssemblyForCallers(
+        string path, string typeName, ReverseLookupOptions options,
+        Func<InboundCallHit, bool> tryAdd, Func<bool> isTruncated)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var pe = new PEReader(stream);
+            if (!pe.HasMetadata) return;
+            var md = pe.GetMetadataReader();
+            var resolver = new MetadataTokenResolver(md);
+
+            foreach (var typeHandle in md.TypeDefinitions)
+            {
+                if (isTruncated()) return;
+                var typeDef = md.GetTypeDefinition(typeHandle);
+                if (!options.IncludeNonPublic && !IsTypeVisible(typeDef.Attributes)) continue;
+
+                var callerType = resolver.TypeDefName(typeHandle);
+
+                foreach (var methodHandle in typeDef.GetMethods())
+                {
+                    var methodDef = md.GetMethodDefinition(methodHandle);
+                    if (!options.IncludeNonPublic && !IsMethodPublic(methodDef.Attributes)) continue;
+                    if (methodDef.RelativeVirtualAddress == 0) continue;
+
+                    MethodBodyBlock body;
+                    try { body = pe.GetMethodBody(methodDef.RelativeVirtualAddress); }
+                    catch (BadImageFormatException) { continue; }
+
+                    var callerMethod = md.GetString(methodDef.Name);
+                    foreach (var tokenRef in IlInstructionReader.ReadTokenInstructions(body.GetILBytes()))
+                    {
+                        var resolved = resolver.Resolve(tokenRef.Token);
+                        if (resolved == null) continue;
+                        if (!MetadataTypeNameMatcher.Matches(resolved.Value.DeclaringType, typeName, options.CaseSensitive)) continue;
+
+                        if (!tryAdd(new InboundCallHit(path, callerType, callerMethod, ReferenceKindName(tokenRef.Kind), resolved.Value.Display)))
+                            return;
+                    }
+                }
+            }
+        }
+        catch (BadImageFormatException) { }
+        catch (FileLoadException) { }
+        catch (FileNotFoundException) { }
+        catch (IOException) { }
+    }
+
+    private static byte[]? TryGetMethodBody(PEReader pe, MetadataReader md, int metadataToken, out bool hadBody)
+    {
+        hadBody = false;
+        EntityHandle handle;
+        try { handle = MetadataTokens.EntityHandle(metadataToken); }
+        catch (ArgumentException) { return null; }
+        if (handle.Kind != HandleKind.MethodDefinition) return null;
+
+        var def = md.GetMethodDefinition((MethodDefinitionHandle)handle);
+        if (def.RelativeVirtualAddress == 0) return null;
+
+        MethodBodyBlock body;
+        try { body = pe.GetMethodBody(def.RelativeVirtualAddress); }
+        catch (BadImageFormatException) { return null; }
+
+        hadBody = true;
+        return body.GetILBytes();
+    }
+
+    private static BindingFlags BuildMemberFlags(bool includeNonPublic)
+    {
+        var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+        if (includeNonPublic) flags |= BindingFlags.NonPublic;
+        return flags;
+    }
+
+    private static IEnumerable<Type> SafeGetTypes(IAssemblyInspectionContext ctx)
+    {
+        try { return ctx.GetTypes(); }
+        catch { return Array.Empty<Type>(); }
+    }
+
+    private static MethodInfo[] SafeGetMethods(Type t, BindingFlags flags)
+    {
+        try { return t.GetMethods(flags); }
+        catch { return Array.Empty<MethodInfo>(); }
+    }
+
+    private static ConstructorInfo[] SafeGetConstructors(Type t, BindingFlags flags)
+    {
+        try { return t.GetConstructors(flags); }
+        catch { return Array.Empty<ConstructorInfo>(); }
+    }
+
+    private static bool NameEquals(string a, string b, bool caseSensitive) =>
+        string.Equals(a, b, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsConstructorName(string methodName) =>
+        methodName is ".ctor" or ".cctor" or "ctor" or "cctor";
+
+    private static bool IsFieldAccess(IlRefKind kind) =>
+        kind is IlRefKind.LdFld or IlRefKind.LdsFld or IlRefKind.StFld or IlRefKind.StsFld;
+
+    private static string FieldAccessName(IlRefKind kind) =>
+        kind is IlRefKind.LdFld or IlRefKind.LdsFld ? "read" : "write";
+
+    private static string CallKindName(IlRefKind kind) => kind switch
+    {
+        IlRefKind.Call => "call",
+        IlRefKind.CallVirt => "callvirt",
+        IlRefKind.NewObj => "newobj",
+        IlRefKind.LdFtn => "ldftn",
+        IlRefKind.LdVirtFtn => "ldvirtftn",
+        _ => "call"
+    };
+
+    private static string ReferenceKindName(IlRefKind kind) => kind switch
+    {
+        IlRefKind.LdFld or IlRefKind.LdsFld => "ilFieldRead",
+        IlRefKind.StFld or IlRefKind.StsFld => "ilFieldWrite",
+        _ => "ilCall"
+    };
+
+    private static bool IsTypeVisible(TypeAttributes attributes)
+    {
+        var visibility = attributes & TypeAttributes.VisibilityMask;
+        return visibility is TypeAttributes.Public or TypeAttributes.NestedPublic;
+    }
+
+    private static bool IsMethodPublic(MethodAttributes attributes) =>
+        (attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Public;
+
+    private static string FormatSignature(MethodBase method)
+    {
+        string ret;
+        try { ret = method is MethodInfo mi ? TypeNameFormatter.FriendlyName(mi.ReturnType) : "void"; }
+        catch { ret = "?"; }
+
+        ParameterInfo[] parameters;
+        try { parameters = method.GetParameters(); }
+        catch { parameters = Array.Empty<ParameterInfo>(); }
+
+        var ps = string.Join(", ", parameters.Select(p =>
+        {
+            string pt;
+            try { pt = TypeNameFormatter.FriendlyName(p.ParameterType); }
+            catch { pt = "?"; }
+            return $"{pt} {p.Name}";
+        }));
+
+        return $"{ret} {method.Name}({ps})";
+    }
+}

--- a/src/runtime/IlAnalysisService.cs
+++ b/src/runtime/IlAnalysisService.cs
@@ -39,9 +39,15 @@ public class IlAnalysisService : IIlAnalysisService
                 {
                     if (NameEquals(method.Name, methodName, options.CaseSensitive)) targets.Add(method);
                 }
-                if (IsConstructorName(methodName))
+                if (IsStaticConstructorName(methodName))
                 {
-                    foreach (var ctor in SafeGetConstructors(candidate, flags)) targets.Add(ctor);
+                    var cctor = SafeGetTypeInitializer(candidate);
+                    if (cctor != null) targets.Add(cctor);
+                }
+                else if (IsInstanceConstructorName(methodName))
+                {
+                    foreach (var ctor in SafeGetConstructors(candidate, flags))
+                        if (!ctor.IsStatic) targets.Add(ctor);
                 }
                 break;
             }
@@ -151,6 +157,7 @@ public class IlAnalysisService : IIlAnalysisService
             if (!pe.HasMetadata) return;
             var md = pe.GetMetadataReader();
             var resolver = new MetadataTokenResolver(md);
+            var seen = new HashSet<string>(StringComparer.Ordinal);
 
             foreach (var typeHandle in md.TypeDefinitions)
             {
@@ -177,7 +184,10 @@ public class IlAnalysisService : IIlAnalysisService
                         if (resolved == null) continue;
                         if (!MetadataTypeNameMatcher.Matches(resolved.Value.DeclaringType, typeName, options.CaseSensitive)) continue;
 
-                        if (!tryAdd(new InboundCallHit(path, callerType, callerMethod, ReferenceKindName(tokenRef.Kind), resolved.Value.Display)))
+                        var referenceKind = ReferenceKindName(tokenRef.Kind);
+                        if (!seen.Add($"{callerType}|{callerMethod}|{referenceKind}|{resolved.Value.Display}")) continue;
+
+                        if (!tryAdd(new InboundCallHit(path, callerType, callerMethod, referenceKind, resolved.Value.Display)))
                             return;
                     }
                 }
@@ -233,11 +243,20 @@ public class IlAnalysisService : IIlAnalysisService
         catch { return Array.Empty<ConstructorInfo>(); }
     }
 
+    private static ConstructorInfo? SafeGetTypeInitializer(Type t)
+    {
+        try { return t.TypeInitializer; }
+        catch { return null; }
+    }
+
     private static bool NameEquals(string a, string b, bool caseSensitive) =>
         string.Equals(a, b, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
 
-    private static bool IsConstructorName(string methodName) =>
-        methodName is ".ctor" or ".cctor" or "ctor" or "cctor";
+    private static bool IsInstanceConstructorName(string methodName) =>
+        methodName is ".ctor" or "ctor";
+
+    private static bool IsStaticConstructorName(string methodName) =>
+        methodName is ".cctor" or "cctor";
 
     private static bool IsFieldAccess(IlRefKind kind) =>
         kind is IlRefKind.LdFld or IlRefKind.LdsFld or IlRefKind.StFld or IlRefKind.StsFld;

--- a/src/runtime/Sherlock.MCP.Runtime.csproj
+++ b/src/runtime/Sherlock.MCP.Runtime.csproj
@@ -5,4 +5,8 @@
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.6" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Sherlock.MCP.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/server/Program.cs
+++ b/src/server/Program.cs
@@ -38,6 +38,7 @@ builder.Services
     .AddSingleton<IXmlDocService, XmlDocService>()
     .AddSingleton<IProjectAnalysisService, ProjectAnalysisService>()
     .AddSingleton<IReverseLookupService, ReverseLookupService>()
+    .AddSingleton<IIlAnalysisService, IlAnalysisService>()
     .AddSingleton<ISearchService, SearchService>()
     .AddSingleton<ToolMiddleware>()
     .AddMcpServer()

--- a/src/server/Tools/IlAnalysisTools.cs
+++ b/src/server/Tools/IlAnalysisTools.cs
@@ -1,0 +1,92 @@
+using ModelContextProtocol.Server;
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Contracts.Il;
+using Sherlock.MCP.Server.Middleware;
+using Sherlock.MCP.Server.Shared;
+using System.ComponentModel;
+
+namespace Sherlock.MCP.Server.Tools;
+
+[McpServerToolType]
+public static class IlAnalysisTools
+{
+    private static readonly string[] MethodNotFoundAlternatives = { "GetTypeMethods", "AnalyzeType" };
+
+    [McpServerTool]
+    [Description("Analyzes a method's IL body to list what it calls and which fields it touches (the 'what does this method call?' question that signature-level tools can't answer). Aggregates across all overloads of the method name. Returns a lean summary by default (distinct target names); projection='full' adds per-call kind (call/callvirt/newobj/ldftn) and the source overload signature.")]
+    public static string GetMethodCalls(
+        IIlAnalysisService ilAnalysis,
+        ToolMiddleware middleware,
+        [Description("Path to the .NET assembly file (.dll or .exe) that declares the method")] string assemblyPath,
+        [Description("Type that declares the method. Simple name, full name, or open-generic form accepted.")] string typeName,
+        [Description("Method name to analyze. Use '.ctor' for instance constructors or '.cctor' for the static constructor. All overloads with this name are aggregated.")] string methodName,
+        [Description("Case sensitive type-name matching (default: false)")] bool caseSensitive = false,
+        [Description("Include non-public methods and the non-public declaring type (default: false)")] bool includeNonPublic = false,
+        [Description("Response shape. 'summary' (default, token-lean): distinct target names only. 'full': adds { target, kind, sourceMethod } per call and { target, access, sourceMethod } per field access.")] string projection = "summary",
+        [Description("Bypass cache for this request")] bool noCache = false)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(assemblyPath))
+                return JsonHelpers.Error("InvalidArgument", "assemblyPath is required");
+            if (!File.Exists(assemblyPath))
+                return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
+            if (string.IsNullOrWhiteSpace(typeName))
+                return JsonHelpers.Error("InvalidArgument", "typeName is required");
+            if (string.IsNullOrWhiteSpace(methodName))
+                return JsonHelpers.Error("InvalidArgument", "methodName is required");
+
+            var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
+            if (normalizedProjection != "summary" && normalizedProjection != "full")
+                return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
+
+            var cacheKey = CacheKeyHelper.Build(
+                "il.methodCalls",
+                CacheKeyHelper.FileStamp(assemblyPath), typeName, methodName, caseSensitive, includeNonPublic, normalizedProjection);
+
+            return middleware.Execute(cacheKey, () =>
+            {
+                var options = new IlAnalysisOptions(CaseSensitive: caseSensitive, IncludeNonPublic: includeNonPublic);
+                var analysis = ilAnalysis.GetMethodCalls(assemblyPath, typeName, methodName, options);
+
+                if (analysis == null)
+                    return JsonHelpers.ErrorWithGuidance(
+                        "MethodNotFound",
+                        $"No method named '{methodName}' was found on type '{typeName}' in {Path.GetFileName(assemblyPath)}.",
+                        "Verify the type and method names. Use GetTypeMethods to list available methods, or set includeNonPublic=true for private methods.",
+                        MethodNotFoundAlternatives);
+
+                object result = normalizedProjection == "summary"
+                    ? new
+                    {
+                        declaringType = analysis.DeclaringTypeFullName,
+                        methodName = analysis.MethodName,
+                        matchedOverloads = analysis.MatchedOverloads,
+                        anyBodyless = analysis.AnyBodyless,
+                        projection = normalizedProjection,
+                        calls = analysis.Calls.Select(c => c.Target).Distinct(StringComparer.Ordinal).ToArray(),
+                        fieldAccesses = analysis.FieldAccesses.Select(f => f.Target).Distinct(StringComparer.Ordinal).ToArray()
+                    }
+                    : new
+                    {
+                        declaringType = analysis.DeclaringTypeFullName,
+                        methodName = analysis.MethodName,
+                        matchedOverloads = analysis.MatchedOverloads,
+                        anyBodyless = analysis.AnyBodyless,
+                        projection = normalizedProjection,
+                        calls = analysis.Calls.Select(c => new { target = c.Target, kind = c.Kind, sourceMethod = c.SourceMethod }).ToArray(),
+                        fieldAccesses = analysis.FieldAccesses.Select(f => new { target = f.Target, access = f.Access, sourceMethod = f.SourceMethod }).ToArray()
+                    };
+
+                var sizeError = ResponseSizeHelper.ValidateResponseSize(result, "GetMethodCalls");
+                if (sizeError != null) return sizeError;
+
+                return JsonHelpers.Envelope("il.methodCalls", result);
+            }, noCache);
+        }
+        catch (Exception ex)
+        {
+            return JsonHelpers.Error("InternalError", $"Failed to analyze method calls: {ex.Message}");
+        }
+    }
+}

--- a/src/server/Tools/ReverseLookupTools.cs
+++ b/src/server/Tools/ReverseLookupTools.cs
@@ -301,9 +301,10 @@ public static class ReverseLookupTools
     }
 
     [McpServerTool]
-    [Description("Finds all references to a type across one or more assemblies: base types, implemented interfaces, method returns/parameters, field/property/event types (recurses into generic arguments). Bounded sweep with hardCap to protect against runaway scans; check truncated=true. Returns lean summary by default; projection='full' adds assemblyPath, signature, dedupeKey.")]
+    [Description("Finds all references to a type across one or more assemblies: base types, implemented interfaces, method returns/parameters, field/property/event types (recurses into generic arguments). With analysisDepth='il', also scans method bodies for inbound callers ('who calls into this type?'). Bounded sweep with hardCap to protect against runaway scans; check truncated=true. Returns lean summary by default; projection='full' adds assemblyPath, signature, dedupeKey.")]
     public static string FindReferencesTo(
         IReverseLookupService reverseLookup,
+        IIlAnalysisService ilAnalysis,
         ToolMiddleware middleware,
         RuntimeOptions runtimeOptions,
         [Description("Path to the primary .NET assembly file (.dll or .exe)")] string assemblyPath,
@@ -311,6 +312,7 @@ public static class ReverseLookupTools
         [Description("Optional additional assembly paths to include in the search scope")] string[]? additionalAssemblies = null,
         [Description("Case sensitive type-name matching (default: false)")] bool caseSensitive = false,
         [Description("Include non-public members and types (default: false)")] bool includeNonPublic = false,
+        [Description("Analysis depth. 'signatures' (default): type usage in signatures and member declarations. 'il': additionally scan method bodies for inbound callers (referenceKind 'ilCall'/'ilFieldRead'/'ilFieldWrite'). IL scanning is slower.")] string analysisDepth = "signatures",
         [Description("Maximum items to return (default: 25)")] int? maxItems = null,
         [Description("Items to skip (paging)")] int? skip = null,
         [Description("Continuation token for paging")] string? continuationToken = null,
@@ -326,14 +328,18 @@ public static class ReverseLookupTools
             if (normalizedProjection != "summary" && normalizedProjection != "full")
                 return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
 
+            var normalizedDepth = (analysisDepth ?? "signatures").Trim().ToLowerInvariant();
+            if (normalizedDepth != "signatures" && normalizedDepth != "il")
+                return JsonHelpers.Error("InvalidAnalysisDepth", "analysisDepth must be 'signatures' or 'il'");
+
             var scopeKey = string.Join(";", scope.Paths.Select(CacheKeyHelper.FileStamp));
             var saltSeed = CacheKeyHelper.Build(
                 "reverselookup.references.salt",
-                scopeKey, typeName, caseSensitive, includeNonPublic);
+                scopeKey, typeName, caseSensitive, includeNonPublic, normalizedDepth);
 
             var cacheKey = CacheKeyHelper.Build(
                 "reverselookup.references",
-                scopeKey, typeName, caseSensitive, includeNonPublic, maxItems, continuationToken, skip, normalizedProjection);
+                scopeKey, typeName, caseSensitive, includeNonPublic, normalizedDepth, maxItems, continuationToken, skip, normalizedProjection);
 
             return middleware.Execute(cacheKey, () =>
             {
@@ -347,6 +353,33 @@ public static class ReverseLookupTools
 
                 var scanResult = reverseLookup.FindReferences(scope.Paths, typeName, options);
                 var allHits = scanResult.Hits;
+                var truncated = scanResult.Truncated;
+
+                if (normalizedDepth == "il")
+                {
+                    var inbound = ilAnalysis.FindInboundCallers(scope.Paths, typeName, options);
+                    if (inbound.Length > 0)
+                    {
+                        var inboundHits = inbound.Select(h => new ReferenceHit(
+                            AssemblyPath: h.AssemblyPath,
+                            DeclaringTypeFullName: h.CallerTypeFullName,
+                            MemberKind: "method",
+                            MemberName: h.CallerMethod,
+                            ReferenceKind: h.ReferenceKind,
+                            Signature: $"{h.CallerMethod} -> {h.TargetMember}",
+                            DedupeKey: $"{h.CallerTypeFullName}|method|{h.CallerMethod}|{h.ReferenceKind}|{h.TargetMember}"));
+
+                        allHits = allHits.Concat(inboundHits)
+                            .OrderBy(h => h.AssemblyPath, StringComparer.Ordinal)
+                            .ThenBy(h => h.DeclaringTypeFullName, StringComparer.Ordinal)
+                            .ThenBy(h => h.MemberKind, StringComparer.Ordinal)
+                            .ThenBy(h => h.MemberName, StringComparer.Ordinal)
+                            .ThenBy(h => h.ReferenceKind, StringComparer.Ordinal)
+                            .ThenBy(h => h.DedupeKey, StringComparer.Ordinal)
+                            .ToArray();
+                    }
+                    truncated = truncated || inbound.Length >= options.HardCap;
+                }
 
                 var offset = 0;
                 var salt = TokenHelper.MakeSalt(saltSeed);
@@ -393,7 +426,7 @@ public static class ReverseLookupTools
                     projection = normalizedProjection,
                     total = allHits.Length,
                     count = page.Length,
-                    truncated = scanResult.Truncated,
+                    truncated,
                     hardCap,
                     nextToken,
                     pagination = PaginationMetadata.Create(allHits.Length, page.Length, nextToken, resultsJson.Length),

--- a/src/unit-tests/IlAnalysisFixtures.cs
+++ b/src/unit-tests/IlAnalysisFixtures.cs
@@ -28,3 +28,12 @@ public class IlSampleSubject
         public abstract void Nothing();
     }
 }
+
+public class StaticCtorSubject
+{
+    private static readonly List<int> _shared = CreateShared();
+
+    private static List<int> CreateShared() => new();
+
+    public int UseShared() => _shared.Count;
+}

--- a/src/unit-tests/IlAnalysisFixtures.cs
+++ b/src/unit-tests/IlAnalysisFixtures.cs
@@ -1,0 +1,30 @@
+namespace Sherlock.MCP.Tests.IlAnalysisFixtures;
+
+public class IlSampleSubject
+{
+    private int _counter;
+    private static string _label = "x";
+
+    public void DoWork()
+    {
+        Console.WriteLine("hi");
+        _counter = Compute(_counter);
+        var list = new List<int>();
+        list.Add(_counter);
+        _counter = list.Count;
+        Helper();
+        _label = "y";
+        Console.WriteLine(_label);
+    }
+
+    public int Helper() => 42;
+
+    public int Helper(int seed) => seed;
+
+    private int Compute(int x) => x + 1;
+
+    public abstract class Bodyless
+    {
+        public abstract void Nothing();
+    }
+}

--- a/src/unit-tests/IlAnalysisServiceTests.cs
+++ b/src/unit-tests/IlAnalysisServiceTests.cs
@@ -75,6 +75,17 @@ public class IlAnalysisServiceTests
     }
 
     [Fact]
+    public void GetMethodCalls_StaticConstructor_AnalyzesTypeInitializerBody()
+    {
+        var result = _svc.GetMethodCalls(_testAssemblyPath, "StaticCtorSubject", ".cctor", _options);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.MatchedOverloads);
+        Assert.False(result.AnyBodyless);
+        Assert.Contains(result.Calls, c => c.Target == $"{typeof(StaticCtorSubject).FullName}.CreateShared");
+    }
+
+    [Fact]
     public void GetMethodCalls_UnknownMethod_ReturnsNull()
     {
         Assert.Null(_svc.GetMethodCalls(_testAssemblyPath, "IlSampleSubject", "NoSuchMethod", _options));
@@ -90,6 +101,21 @@ public class IlAnalysisServiceTests
             h.CallerTypeFullName == SubjectFullName &&
             h.CallerMethod == "DoWork" &&
             h.ReferenceKind == "ilCall");
+    }
+
+    [Fact]
+    public void FindInboundCallers_DeduplicatesRepeatedCallsToSameTarget()
+    {
+        // DoWork calls Console.WriteLine twice; the inbound hit must appear only once.
+        var hits = _svc.FindInboundCallers([_testAssemblyPath], "Console", new ReverseLookupOptions());
+
+        var writeLineFromDoWork = hits.Count(h =>
+            h.CallerTypeFullName == SubjectFullName &&
+            h.CallerMethod == "DoWork" &&
+            h.TargetMember == "System.Console.WriteLine" &&
+            h.ReferenceKind == "ilCall");
+
+        Assert.Equal(1, writeLineFromDoWork);
     }
 
     [Fact]

--- a/src/unit-tests/IlAnalysisServiceTests.cs
+++ b/src/unit-tests/IlAnalysisServiceTests.cs
@@ -1,0 +1,105 @@
+using System.Reflection;
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Contracts.Il;
+using Sherlock.MCP.Runtime.Contracts.ReverseLookup;
+using Sherlock.MCP.Tests.IlAnalysisFixtures;
+
+namespace Sherlock.MCP.Tests;
+
+public class IlAnalysisServiceTests
+{
+    private readonly IIlAnalysisService _svc = new IlAnalysisService();
+    private readonly string _testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+    private readonly IlAnalysisOptions _options = new();
+
+    private static readonly string SubjectFullName = typeof(IlSampleSubject).FullName!;
+    private const string ListFullName = "System.Collections.Generic.List`1";
+
+    [Fact]
+    public void GetMethodCalls_Summary_IncludesLocalBclAndGenericTargets()
+    {
+        var result = _svc.GetMethodCalls(_testAssemblyPath, "IlSampleSubject", "DoWork", _options);
+
+        Assert.NotNull(result);
+        var targets = result!.Calls.Select(c => c.Target).ToArray();
+
+        Assert.Contains("System.Console.WriteLine", targets);
+        Assert.Contains($"{SubjectFullName}.Helper", targets);
+        Assert.Contains($"{SubjectFullName}.Compute", targets);
+        Assert.Contains($"{ListFullName}..ctor", targets);
+        Assert.Contains($"{ListFullName}.Add", targets);
+    }
+
+    [Fact]
+    public void GetMethodCalls_TracksFieldReadAndWrite()
+    {
+        var result = _svc.GetMethodCalls(_testAssemblyPath, "IlSampleSubject", "DoWork", _options);
+
+        Assert.NotNull(result);
+        var counterField = $"{SubjectFullName}._counter";
+        var labelField = $"{SubjectFullName}._label";
+
+        Assert.Contains(result!.FieldAccesses, f => f.Target == counterField && f.Access == "read");
+        Assert.Contains(result.FieldAccesses, f => f.Target == counterField && f.Access == "write");
+        Assert.Contains(result.FieldAccesses, f => f.Target == labelField && f.Access == "write");
+    }
+
+    [Fact]
+    public void GetMethodCalls_NewObj_HasNewObjKind()
+    {
+        var result = _svc.GetMethodCalls(_testAssemblyPath, "IlSampleSubject", "DoWork", _options);
+
+        Assert.NotNull(result);
+        Assert.Contains(result!.Calls, c => c.Target == $"{ListFullName}..ctor" && c.Kind == "newobj");
+    }
+
+    [Fact]
+    public void GetMethodCalls_AggregatesAllOverloads()
+    {
+        var result = _svc.GetMethodCalls(_testAssemblyPath, "IlSampleSubject", "Helper", _options);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result!.MatchedOverloads);
+        Assert.False(result.AnyBodyless);
+    }
+
+    [Fact]
+    public void GetMethodCalls_AbstractMethod_ReportsBodyless()
+    {
+        var result = _svc.GetMethodCalls(_testAssemblyPath, "Bodyless", "Nothing", _options);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.MatchedOverloads);
+        Assert.True(result.AnyBodyless);
+        Assert.Empty(result.Calls);
+    }
+
+    [Fact]
+    public void GetMethodCalls_UnknownMethod_ReturnsNull()
+    {
+        Assert.Null(_svc.GetMethodCalls(_testAssemblyPath, "IlSampleSubject", "NoSuchMethod", _options));
+        Assert.Null(_svc.GetMethodCalls(_testAssemblyPath, "NoSuchType", "DoWork", _options));
+    }
+
+    [Fact]
+    public void FindInboundCallers_FindsCallerOfExternalType()
+    {
+        var hits = _svc.FindInboundCallers([_testAssemblyPath], "Console", new ReverseLookupOptions());
+
+        Assert.Contains(hits, h =>
+            h.CallerTypeFullName == SubjectFullName &&
+            h.CallerMethod == "DoWork" &&
+            h.ReferenceKind == "ilCall");
+    }
+
+    [Fact]
+    public void FindInboundCallers_FindsCallerOfLocalType()
+    {
+        var hits = _svc.FindInboundCallers([_testAssemblyPath], "IlSampleSubject", new ReverseLookupOptions());
+
+        Assert.Contains(hits, h =>
+            h.CallerTypeFullName == SubjectFullName &&
+            h.CallerMethod == "DoWork" &&
+            h.TargetMember == $"{SubjectFullName}.Compute");
+    }
+}

--- a/src/unit-tests/IlInstructionReaderTests.cs
+++ b/src/unit-tests/IlInstructionReaderTests.cs
@@ -1,0 +1,96 @@
+using Sherlock.MCP.Runtime.Il;
+
+namespace Sherlock.MCP.Tests;
+
+public class IlInstructionReaderTests
+{
+    private const int SampleToken = 0x06000001;
+    private static readonly byte[] SampleTokenBytes = { 0x01, 0x00, 0x00, 0x06 };
+
+    [Fact]
+    public void EmptyOrNull_YieldsNothing()
+    {
+        Assert.Empty(IlInstructionReader.ReadTokenInstructions(null));
+        Assert.Empty(IlInstructionReader.ReadTokenInstructions(Array.Empty<byte>()));
+    }
+
+    [Fact]
+    public void EightByteOperand_DoesNotDesyncFollowingCallToken()
+    {
+        // nop; ldc.i8 <8 bytes>; call <token>; ret
+        var il = new List<byte> { 0x00, 0x21 };
+        il.AddRange(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+        il.Add(0x28);
+        il.AddRange(SampleTokenBytes);
+        il.Add(0x2A);
+
+        var refs = IlInstructionReader.ReadTokenInstructions(il.ToArray()).ToArray();
+
+        var single = Assert.Single(refs);
+        Assert.Equal(IlRefKind.Call, single.Kind);
+        Assert.Equal(SampleToken, single.Token);
+    }
+
+    [Fact]
+    public void Switch_VariableOperand_DoesNotDesyncFollowingCallToken()
+    {
+        // switch (count=2) target0 target1; call <token>; ret
+        var il = new List<byte> { 0x45 };
+        il.AddRange(new byte[] { 0x02, 0x00, 0x00, 0x00 });
+        il.AddRange(new byte[] { 0xAA, 0xAA, 0xAA, 0xAA });
+        il.AddRange(new byte[] { 0xBB, 0xBB, 0xBB, 0xBB });
+        il.Add(0x28);
+        il.AddRange(SampleTokenBytes);
+        il.Add(0x2A);
+
+        var refs = IlInstructionReader.ReadTokenInstructions(il.ToArray()).ToArray();
+
+        var single = Assert.Single(refs);
+        Assert.Equal(IlRefKind.Call, single.Kind);
+        Assert.Equal(SampleToken, single.Token);
+    }
+
+    [Fact]
+    public void TrailingPrefixByte_StopsGracefully()
+    {
+        // call <token>; lone 0xFE prefix with no second byte
+        var il = new List<byte> { 0x28 };
+        il.AddRange(SampleTokenBytes);
+        il.Add(0xFE);
+
+        var refs = IlInstructionReader.ReadTokenInstructions(il.ToArray()).ToArray();
+
+        var single = Assert.Single(refs);
+        Assert.Equal(IlRefKind.Call, single.Kind);
+    }
+
+    [Fact]
+    public void ClassifiesCallFieldAndNewObjOpcodes()
+    {
+        // newobj <tok>; callvirt <tok>; ldsfld <tok>; stfld <tok>; ret
+        var il = new List<byte>();
+        il.Add(0x73); il.AddRange(SampleTokenBytes);
+        il.Add(0x6F); il.AddRange(SampleTokenBytes);
+        il.Add(0x7E); il.AddRange(SampleTokenBytes);
+        il.Add(0x7D); il.AddRange(SampleTokenBytes);
+        il.Add(0x2A);
+
+        var kinds = IlInstructionReader.ReadTokenInstructions(il.ToArray()).Select(r => r.Kind).ToArray();
+
+        Assert.Equal(
+            new[] { IlRefKind.NewObj, IlRefKind.CallVirt, IlRefKind.LdsFld, IlRefKind.StFld },
+            kinds);
+    }
+
+    [Fact]
+    public void TwoByteLdftn_IsClassified()
+    {
+        // ldftn (0xFE 0x06) <token>; ret
+        var il = new List<byte> { 0xFE, 0x06 };
+        il.AddRange(SampleTokenBytes);
+        il.Add(0x2A);
+
+        var single = Assert.Single(IlInstructionReader.ReadTokenInstructions(il.ToArray()).ToArray());
+        Assert.Equal(IlRefKind.LdFtn, single.Kind);
+    }
+}

--- a/src/unit-tests/ReverseLookupToolsTests.cs
+++ b/src/unit-tests/ReverseLookupToolsTests.cs
@@ -12,6 +12,7 @@ namespace Sherlock.MCP.Tests;
 public class ReverseLookupToolsTests
 {
     private readonly IReverseLookupService _svc = new ReverseLookupService();
+    private readonly IIlAnalysisService _il = new IlAnalysisService();
     private readonly RuntimeOptions _runtimeOptions = new();
     private readonly ToolMiddleware _middleware;
     private readonly string _testAssemblyPath = Assembly.GetExecutingAssembly().Location;
@@ -231,7 +232,7 @@ public class ReverseLookupToolsTests
     public void FindReferencesTo_Envelope_IncludesTruncatedFlag()
     {
         var result = ReverseLookupTools.FindReferencesTo(
-            _svc, _middleware, _runtimeOptions,
+            _svc, _il, _middleware, _runtimeOptions,
             _testAssemblyPath, "RecordedEvent", noCache: true);
 
         Assert.DoesNotContain("\"error\"", result);
@@ -247,7 +248,7 @@ public class ReverseLookupToolsTests
     public void FindReferencesTo_SmallMaxItems_ReportsFloor500HardCap()
     {
         var result = ReverseLookupTools.FindReferencesTo(
-            _svc, _middleware, _runtimeOptions,
+            _svc, _il, _middleware, _runtimeOptions,
             _testAssemblyPath, "RecordedEvent", maxItems: 1, noCache: true);
 
         var data = JsonDocument.Parse(result).RootElement.GetProperty("data");
@@ -261,7 +262,7 @@ public class ReverseLookupToolsTests
     public void FindReferencesTo_LargeMaxItems_ScalesHardCapAboveFloor()
     {
         var result = ReverseLookupTools.FindReferencesTo(
-            _svc, _middleware, _runtimeOptions,
+            _svc, _il, _middleware, _runtimeOptions,
             _testAssemblyPath, "RecordedEvent", maxItems: 200, noCache: true);
 
         var data = JsonDocument.Parse(result).RootElement.GetProperty("data");
@@ -272,7 +273,7 @@ public class ReverseLookupToolsTests
     public void FindReferencesTo_ContinuationToken_RoundTrips()
     {
         var page1 = ReverseLookupTools.FindReferencesTo(
-            _svc, _middleware, _runtimeOptions,
+            _svc, _il, _middleware, _runtimeOptions,
             _testAssemblyPath, "RecordedEvent", maxItems: 1, noCache: true);
 
         var page1Data = JsonDocument.Parse(page1).RootElement.GetProperty("data");
@@ -282,7 +283,7 @@ public class ReverseLookupToolsTests
         Assert.False(string.IsNullOrEmpty(nextToken));
 
         var page2 = ReverseLookupTools.FindReferencesTo(
-            _svc, _middleware, _runtimeOptions,
+            _svc, _il, _middleware, _runtimeOptions,
             _testAssemblyPath, "RecordedEvent",
             maxItems: 1, continuationToken: nextToken, noCache: true);
 


### PR DESCRIPTION
## Summary

Implements issue #35 — IL call analysis. Method bodies were previously invisible to reverse lookup (signature-surface only). This adds an IL-reading layer using `System.Reflection.Metadata` (`PEReader`) and exposes two capabilities:

- **`GetMethodCalls` tool** (outbound) — "what does this method call?" Lists call/`newobj`/`ldftn` targets and field reads/writes from a method's IL body, aggregated across all overloads. Lean summary by default (distinct target names); `projection='full'` adds per-call kind and source overload signature.
- **`analysisDepth='il'` on `FindReferencesTo`** (inbound) — "who calls into this type?" Scans method bodies for callers and merges them into the existing reference results as `referenceKind` `ilCall`/`ilFieldRead`/`ilFieldWrite`. Default stays `'signatures'` (lean), so existing behavior is unchanged.

### Design notes
- `MetadataLoadContext` can't read method bodies, so IL bytes come from a separate `PEReader`; the bridge is `MethodInfo.MetadataToken` → `MethodDefinitionHandle` (same physical file).
- The IL decoder's operand-size table is **derived from `System.Reflection.Emit.OpCodes`** rather than hand-transcribed — a wrong width would silently desync the instruction pointer.
- Token resolution includes a string-producing `ISignatureTypeProvider` so generic-instantiated calls (e.g. `List<int>.Add`) resolve to the open generic type def name.
- All metadata APIs are in-box in the shared framework — no new package reference.

## Test plan
- ✅ Full solution builds clean across **net8.0/9.0/10.0** with warnings-as-errors.
- ✅ **174/174 unit tests pass** (14 new), no regressions:
  - Decoder edge cases over hand-built IL: 8-byte (`ldc.i8`) and `switch` operands don't desync; trailing lone `0xFE` stops gracefully; opcode classification (`call`/`callvirt`/`newobj`/`ldftn`/field ops).
  - Service: summary/full projections, overload aggregation, abstract/bodyless methods, not-found → null, inbound callers for both local and external (`Console`) types.
- ✅ Live MCP smoke over stdio: server registers `get_method_calls`; end-to-end `tools/call` returned the correct `il.methodCalls` envelope with `call`/`callvirt`/`newobj` kinds, the `List\`1..ctor` newobj, and `_counter`/`_label` read+write field accesses.

Note: tests execute on net10.0 locally (no net9.0 runtime installed; net9 builds fine).

Closes #35