### PR TITLE
feat: populate GetTypeHierarchy DerivedTypes via optional additionalAssemblies

### DIFF
--- a/src/runtime/Contracts/TypeAnalysis/TypeHierarchy.cs
+++ b/src/runtime/Contracts/TypeAnalysis/TypeHierarchy.cs
@@ -1,9 +1,16 @@
 namespace Sherlock.MCP.Runtime.Contracts.TypeAnalysis;
 
+public record DerivedTypeRef(
+    string TypeFullName,
+    string AssemblyPath,
+    string Kind
+);
+
 public record TypeHierarchy(
     string TypeName,
     string[] InheritanceChain,
     string[] AllInterfaces,
     TypeInfo[] BaseTypes,
-    TypeInfo[] DerivedTypes
+    DerivedTypeRef[]? DerivedTypes,
+    string? Note
 );

--- a/src/runtime/TypeAnalysisService.cs
+++ b/src/runtime/TypeAnalysisService.cs
@@ -157,15 +157,13 @@ public class TypeAnalysisService : ITypeAnalysisService, IDisposable
             .Select(TypeNameFormatter.FriendlyFullName)
             .ToArray();
 
-        // Note: Getting derived types requires scanning all loaded assemblies
-        // This is expensive and might not be practical in all scenarios
-        var derivedTypes = Array.Empty<TypeAnalysisInfo>();
         return new TypeAnalysisHierarchy(
             TypeName: TypeNameFormatter.FriendlyFullName(type),
             InheritanceChain: inheritanceChain.ToArray(),
             AllInterfaces: allInterfaces,
             BaseTypes: baseTypes.ToArray(),
-            DerivedTypes: derivedTypes
+            DerivedTypes: null,
+            Note: null
         );
     }
 

--- a/src/server/Shared/AssemblyScope.cs
+++ b/src/server/Shared/AssemblyScope.cs
@@ -1,0 +1,40 @@
+namespace Sherlock.MCP.Server.Shared;
+
+internal static class AssemblyScope
+{
+    internal readonly struct ScopeResult
+    {
+        public string[] Paths { get; init; }
+        public string? Error { get; init; }
+    }
+
+    public static ScopeResult BuildAndValidate(string assemblyPath, string[]? additionalAssemblies)
+    {
+        if (string.IsNullOrWhiteSpace(assemblyPath))
+            return new ScopeResult { Error = JsonHelpers.Error("InvalidArgument", "assemblyPath is required") };
+        if (!File.Exists(assemblyPath))
+            return new ScopeResult { Error = JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}") };
+
+        var pathComparer = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        var seen = new HashSet<string>(pathComparer);
+        var paths = new List<string>();
+
+        var normalizedPrimary = Path.GetFullPath(assemblyPath);
+        if (seen.Add(normalizedPrimary)) paths.Add(normalizedPrimary);
+
+        if (additionalAssemblies != null)
+        {
+            foreach (var extra in additionalAssemblies)
+            {
+                if (string.IsNullOrWhiteSpace(extra)) continue;
+                if (!File.Exists(extra))
+                    return new ScopeResult { Error = JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {extra}") };
+                var normalizedExtra = Path.GetFullPath(extra);
+                if (seen.Add(normalizedExtra)) paths.Add(normalizedExtra);
+            }
+        }
+        return new ScopeResult { Paths = paths.ToArray() };
+    }
+}

--- a/src/server/Tools/ReverseLookupTools.cs
+++ b/src/server/Tools/ReverseLookupTools.cs
@@ -32,7 +32,7 @@ public static class ReverseLookupTools
     {
         try
         {
-            var scope = BuildAndValidateScope(assemblyPath, additionalAssemblies);
+            var scope = AssemblyScope.BuildAndValidate(assemblyPath, additionalAssemblies);
             if (scope.Error != null) return scope.Error;
 
             var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
@@ -124,7 +124,7 @@ public static class ReverseLookupTools
     {
         try
         {
-            var scope = BuildAndValidateScope(assemblyPath, additionalAssemblies);
+            var scope = AssemblyScope.BuildAndValidate(assemblyPath, additionalAssemblies);
             if (scope.Error != null) return scope.Error;
 
             var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
@@ -222,7 +222,7 @@ public static class ReverseLookupTools
     {
         try
         {
-            var scope = BuildAndValidateScope(assemblyPath, additionalAssemblies);
+            var scope = AssemblyScope.BuildAndValidate(assemblyPath, additionalAssemblies);
             if (scope.Error != null) return scope.Error;
 
             var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
@@ -321,7 +321,7 @@ public static class ReverseLookupTools
     {
         try
         {
-            var scope = BuildAndValidateScope(assemblyPath, additionalAssemblies);
+            var scope = AssemblyScope.BuildAndValidate(assemblyPath, additionalAssemblies);
             if (scope.Error != null) return scope.Error;
 
             var normalizedProjection = (projection ?? "summary").Trim().ToLowerInvariant();
@@ -443,41 +443,5 @@ public static class ReverseLookupTools
         {
             return JsonHelpers.Error("InternalError", $"Failed to find references: {ex.Message}");
         }
-    }
-
-    private readonly struct ScopeResult
-    {
-        public string[] Paths { get; init; }
-        public string? Error { get; init; }
-    }
-
-    private static ScopeResult BuildAndValidateScope(string assemblyPath, string[]? additionalAssemblies)
-    {
-        if (string.IsNullOrWhiteSpace(assemblyPath))
-            return new ScopeResult { Error = JsonHelpers.Error("InvalidArgument", "assemblyPath is required") };
-        if (!File.Exists(assemblyPath))
-            return new ScopeResult { Error = JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}") };
-
-        var pathComparer = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
-            ? StringComparer.OrdinalIgnoreCase
-            : StringComparer.Ordinal;
-        var seen = new HashSet<string>(pathComparer);
-        var paths = new List<string>();
-
-        var normalizedPrimary = Path.GetFullPath(assemblyPath);
-        if (seen.Add(normalizedPrimary)) paths.Add(normalizedPrimary);
-
-        if (additionalAssemblies != null)
-        {
-            foreach (var extra in additionalAssemblies)
-            {
-                if (string.IsNullOrWhiteSpace(extra)) continue;
-                if (!File.Exists(extra))
-                    return new ScopeResult { Error = JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {extra}") };
-                var normalizedExtra = Path.GetFullPath(extra);
-                if (seen.Add(normalizedExtra)) paths.Add(normalizedExtra);
-            }
-        }
-        return new ScopeResult { Paths = paths.ToArray() };
     }
 }

--- a/src/server/Tools/TypeAnalysisTools.cs
+++ b/src/server/Tools/TypeAnalysisTools.cs
@@ -127,7 +127,7 @@ public static class TypeAnalysisTools
             var scope = AssemblyScope.BuildAndValidate(assemblyPath, additionalAssemblies);
             if (scope.Error != null) return scope.Error;
 
-            var hits = reverseLookup.FindImplementations(scope.Paths, typeName, new ReverseLookupOptions());
+            var hits = reverseLookup.FindImplementations(scope.Paths, hierarchy.TypeName, new ReverseLookupOptions());
             var derived = hits.Select(h => new DerivedTypeRef(h.TypeFullName, h.AssemblyPath, h.Kind)).ToArray();
             return JsonHelpers.Envelope("type.hierarchy", hierarchy with { DerivedTypes = derived, Note = null });
         }

--- a/src/server/Tools/TypeAnalysisTools.cs
+++ b/src/server/Tools/TypeAnalysisTools.cs
@@ -1,5 +1,7 @@
 using ModelContextProtocol.Server;
 using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Contracts.ReverseLookup;
+using Sherlock.MCP.Runtime.Contracts.TypeAnalysis;
 using Sherlock.MCP.Server.Shared;
 using System.ComponentModel;
 using System.Reflection;
@@ -103,19 +105,31 @@ public static class TypeAnalysisTools
     }
 
     [McpServerTool]
-    [Description("Gets full inheritance chain and implemented interfaces for a type. Use to understand type relationships and find inherited members. Lightweight response.")]
+    [Description("Gets full inheritance chain and implemented interfaces for a type. Use to understand type relationships and find inherited members. Lightweight response. By default derivedTypes is null with a note - pass additionalAssemblies to compute derived/implementing types via the same scan as FindImplementationsOf.")]
     public static string GetTypeHierarchy(
         ITypeAnalysisService typeAnalysis,
+        IReverseLookupService reverseLookup,
         [Description("Path to the .NET assembly file (.dll or .exe)")] string assemblyPath,
         [Description("Type name to analyze. Prefer full name")]
-        string typeName)
+        string typeName,
+        [Description("Optional additional assembly paths to include in the search scope")]
+        string[]? additionalAssemblies = null)
     {
         try
         {
             if (!File.Exists(assemblyPath)) return JsonHelpers.Error("AssemblyNotFound", $"Assembly file not found: {assemblyPath}");
             var hierarchy = typeAnalysis.GetTypeHierarchy(assemblyPath, typeName);
             if (hierarchy == null) return JsonHelpers.Error("TypeNotFound", $"Type '{typeName}' not found in assembly");
-            return JsonHelpers.Envelope("type.hierarchy", hierarchy);
+
+            if (additionalAssemblies == null || additionalAssemblies.Length == 0)
+                return JsonHelpers.Envelope("type.hierarchy", hierarchy with { Note = "derivedTypes not computed; pass additionalAssemblies to compute, or use FindImplementationsOf" });
+
+            var scope = AssemblyScope.BuildAndValidate(assemblyPath, additionalAssemblies);
+            if (scope.Error != null) return scope.Error;
+
+            var hits = reverseLookup.FindImplementations(scope.Paths, typeName, new ReverseLookupOptions());
+            var derived = hits.Select(h => new DerivedTypeRef(h.TypeFullName, h.AssemblyPath, h.Kind)).ToArray();
+            return JsonHelpers.Envelope("type.hierarchy", hierarchy with { DerivedTypes = derived, Note = null });
         }
         catch (Exception ex)
         {

--- a/src/unit-tests/TypeAnalysisServiceTests.cs
+++ b/src/unit-tests/TypeAnalysisServiceTests.cs
@@ -42,6 +42,8 @@ public class TypeAnalysisServiceTests
         Assert.Equal(type.FullName, hierarchy.TypeName);
         Assert.Contains(typeof(BaseSample).FullName, hierarchy.InheritanceChain);
         Assert.Contains(typeof(IDisposable).FullName, hierarchy.AllInterfaces);
+        Assert.Null(hierarchy.DerivedTypes);
+        Assert.Null(hierarchy.Note);
     }
 
     [Fact]

--- a/src/unit-tests/TypeHierarchyToolTests.cs
+++ b/src/unit-tests/TypeHierarchyToolTests.cs
@@ -1,0 +1,68 @@
+using System.Reflection;
+using System.Text.Json;
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Server.Tools;
+
+namespace Sherlock.MCP.Tests;
+
+public class TypeHierarchyToolTests
+{
+    private readonly ITypeAnalysisService _typeAnalysis = new TypeAnalysisService();
+    private readonly IReverseLookupService _reverseLookup = new ReverseLookupService();
+    private readonly string _testAssemblyPath = Assembly.GetExecutingAssembly().Location;
+
+    [Fact]
+    public void GetTypeHierarchy_WithoutScope_ReturnsNullDerivedTypes_AndNote()
+    {
+        var result = TypeAnalysisTools.GetTypeHierarchy(
+            _typeAnalysis, _reverseLookup, _testAssemblyPath, "BaseSample");
+
+        Assert.DoesNotContain("\"error\"", result);
+        var data = JsonDocument.Parse(result).RootElement.GetProperty("data");
+        Assert.Equal(JsonValueKind.Null, data.GetProperty("DerivedTypes").ValueKind);
+        Assert.False(string.IsNullOrWhiteSpace(data.GetProperty("Note").GetString()));
+    }
+
+    [Fact]
+    public void GetTypeHierarchy_WithScope_PopulatesDerivedTypes_AndNullNote()
+    {
+        var result = TypeAnalysisTools.GetTypeHierarchy(
+            _typeAnalysis, _reverseLookup, _testAssemblyPath, "BaseSample",
+            additionalAssemblies: new[] { _testAssemblyPath });
+
+        Assert.DoesNotContain("\"error\"", result);
+        var data = JsonDocument.Parse(result).RootElement.GetProperty("data");
+        Assert.Equal(JsonValueKind.Null, data.GetProperty("Note").ValueKind);
+
+        var derived = data.GetProperty("DerivedTypes");
+        Assert.Equal(JsonValueKind.Array, derived.ValueKind);
+        Assert.True(derived.GetArrayLength() > 0);
+
+        var hit = Enumerable.Range(0, derived.GetArrayLength())
+            .Select(i => derived[i])
+            .FirstOrDefault(e => e.GetProperty("TypeFullName").GetString()!.Contains("DerivedSample"));
+        Assert.Equal(JsonValueKind.Object, hit.ValueKind);
+        Assert.Equal("baseType", hit.GetProperty("Kind").GetString());
+        Assert.True(hit.TryGetProperty("AssemblyPath", out _));
+    }
+
+    [Fact]
+    public void GetTypeHierarchy_TypeNotFound_ReturnsError()
+    {
+        var result = TypeAnalysisTools.GetTypeHierarchy(
+            _typeAnalysis, _reverseLookup, _testAssemblyPath, "NoSuchTypeXyz");
+
+        Assert.Contains("TypeNotFound", result);
+    }
+
+    [Fact]
+    public void GetTypeHierarchy_MissingAdditionalAssembly_ReturnsError()
+    {
+        var result = TypeAnalysisTools.GetTypeHierarchy(
+            _typeAnalysis, _reverseLookup, _testAssemblyPath, "BaseSample",
+            additionalAssemblies: new[] { "/tmp/does-not-exist.dll" });
+
+        Assert.Contains("AssemblyNotFound", result);
+        Assert.Contains("does-not-exist", result);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #38. `GetTypeHierarchy` no longer returns a misleading empty `DerivedTypes` array — consumers (and LLMs) can now distinguish "no derived types" from "not computed".

- **Default (lean):** `DerivedTypes: null` + a `Note` pointing at `FindImplementationsOf`.
- **Opt-in:** pass `additionalAssemblies` → derived/implementing types computed by reusing `ReverseLookupService.FindImplementations`, returned as lean `{ TypeFullName, AssemblyPath, Kind }` entries.
- Extracted the shared scope-validation logic (`BuildAndValidate` + `ScopeResult`) out of `ReverseLookupTools` into a new `src/server/Shared/AssemblyScope.cs`; the 4 reverse-lookup tools now reuse it (pure refactor, no behavior change).

### Contract change
`TypeHierarchy.DerivedTypes` changed from `TypeInfo[]` to `DerivedTypeRef[]?`, plus a new `string? Note` field. The field was always empty before, so no real consumer depended on its content.

## Test plan

- `dotnet build` — clean across net8.0 / net9.0 / net10.0.
- `dotnet test` — 180/180 unit tests pass (ran on net10.0; net9.0 runtime not installed locally).
- New `TypeHierarchyToolTests.cs` covers: null-default + note, populated scope with correct `kind`, `TypeNotFound`, and `AssemblyNotFound` (proves shared helper is wired). Existing `ReverseLookupToolsTests` confirm the refactor didn't regress.