### PR TITLE
feat: end-to-end MCP integration tests over stdio

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Since the MCP server runs as a separate process, it cannot access the client's l
 - **Assembly Discovery & Analysis** (4 tools): `AnalyzeAssembly`, `GetAssemblyInfo`, `FindAssemblyByClassName`, `FindAssemblyByFileName`
 - **Type Introspection** (7 tools): `GetTypesFromAssembly`, `GetTypeInfo`, `GetTypeHierarchy`, etc.
 - **Member Analysis** (8 tools): `GetTypeMethods`, `GetTypeProperties`, `GetAllTypeMembers`, etc.
+- **Member Search** (1 tool): `SearchMembers`
 - **Reverse Lookup & IL Analysis** (5 tools): `FindImplementationsOf`, `FindMethodsReturning`, `FindExtensionMethodsFor`, `FindReferencesTo` (supports `analysisDepth='il'` for inbound callers), `GetMethodCalls` (outbound IL call/field analysis)
 - **Attributes & Metadata** (2 tools): `GetMemberAttributes`, `GetParameterAttributes`
 - **XML Documentation** (2 tools): `GetXmlDocsForType`, `GetXmlDocsForMember`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,13 +32,13 @@ This is a comprehensive .NET MCP (Model Context Protocol) server called "Sherloc
 This MCP server provides LLMs with comprehensive .NET reflection capabilities through several key architectural principles:
 
 ### Assembly-First Discovery
-Since the MCP server runs as a separate process, it cannot access the client's loaded assemblies. Instead, it provides 35 specialized tools for clients to:
+Since the MCP server runs as a separate process, it cannot access the client's loaded assemblies. Instead, it provides 36 specialized tools for clients to:
 1. **Discover assemblies** using multiple strategies (project analysis, class name search, file system scanning)
 2. **Load and analyze** specific assemblies by path with efficient caching
 3. **Deep introspection** of types, members, attributes, and XML documentation
 4. **Performance optimization** through pagination, streaming, and response size validation
 
-### Tool Categories (35 Available)
+### Tool Categories (36 Available)
 - **Assembly Discovery & Analysis** (4 tools): `AnalyzeAssembly`, `GetAssemblyInfo`, `FindAssemblyByClassName`, `FindAssemblyByFileName`
 - **Type Introspection** (7 tools): `GetTypesFromAssembly`, `GetTypeInfo`, `GetTypeHierarchy`, etc.
 - **Member Analysis** (8 tools): `GetTypeMethods`, `GetTypeProperties`, `GetAllTypeMembers`, etc.

--- a/src/integration-tests/McpStdioProtocolTests.cs
+++ b/src/integration-tests/McpStdioProtocolTests.cs
@@ -82,7 +82,7 @@ public class McpStdioProtocolTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         await using var client = await ConnectAsync(cts.Token);
 
-        var firstData = Envelope(await CallGetTypeMethods(client, maxItems: 10, continuationToken: null, cts.Token))
+        var firstData = Envelope(await CallGetTypeMethods(client, maxItems: 10, continuationToken: null, cancellationToken: cts.Token))
             .GetProperty("data");
 
         var totalPage1 = firstData.GetProperty("total").GetInt32();
@@ -94,7 +94,7 @@ public class McpStdioProtocolTests
         var firstSignatures = Signatures(firstData);
         Assert.Equal(10, firstSignatures.Count);
 
-        var secondData = Envelope(await CallGetTypeMethods(client, maxItems: 10, continuationToken: nextToken, cts.Token))
+        var secondData = Envelope(await CallGetTypeMethods(client, maxItems: 10, continuationToken: nextToken, cancellationToken: cts.Token))
             .GetProperty("data");
 
         Assert.Equal(totalPage1, secondData.GetProperty("total").GetInt32());

--- a/src/integration-tests/McpStdioProtocolTests.cs
+++ b/src/integration-tests/McpStdioProtocolTests.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+namespace Sherlock.MCP.IntegrationTests;
+
+public class McpStdioProtocolTests
+{
+    private const int ExpectedToolCount = 36;
+
+    private static readonly Regex SnakeCase = new("^[a-z0-9]+(_[a-z0-9]+)*$", RegexOptions.Compiled);
+
+    private static string ServerDll => Path.Combine(AppContext.BaseDirectory, "Sherlock.MCP.Server.dll");
+
+    [Fact]
+    public async Task Initialize_handshake_succeeds()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        await using var client = await ConnectAsync(cts.Token);
+
+        Assert.NotNull(client.ServerInfo);
+        Assert.False(string.IsNullOrWhiteSpace(client.ServerInfo!.Name));
+    }
+
+    [Fact]
+    public async Task Tools_list_returns_expected_count_and_snake_case_names()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        await using var client = await ConnectAsync(cts.Token);
+
+        var tools = await client.ListToolsAsync(cancellationToken: cts.Token);
+        var names = tools.Select(t => t.Name).ToHashSet();
+
+        Assert.True(
+            tools.Count == ExpectedToolCount,
+            $"Expected {ExpectedToolCount} tools but server exposed {tools.Count}. " +
+            $"If a tool was intentionally added or removed, update ExpectedToolCount. " +
+            $"Tools: {string.Join(", ", names.OrderBy(n => n))}");
+
+        Assert.Contains("get_type_methods", names);
+        Assert.Contains("find_implementations_of", names);
+        Assert.Contains("update_runtime_options", names);
+
+        foreach (var name in names)
+            Assert.True(SnakeCase.IsMatch(name), $"Tool name '{name}' is not snake_case.");
+    }
+
+    [Fact]
+    public async Task Call_get_type_methods_returns_well_formed_envelope()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        await using var client = await ConnectAsync(cts.Token);
+
+        var result = await client.CallToolAsync(
+            "get_type_methods",
+            new Dictionary<string, object?>
+            {
+                ["assemblyPath"] = typeof(string).Assembly.Location,
+                ["typeName"] = "System.String"
+            },
+            cancellationToken: cts.Token);
+
+        Assert.NotEqual(true, result.IsError);
+
+        var envelope = Envelope(result);
+        Assert.Equal("member.methods", envelope.GetProperty("kind").GetString());
+        Assert.Equal("1.0.0", envelope.GetProperty("version").GetString());
+
+        var data = envelope.GetProperty("data");
+        var total = data.GetProperty("total").GetInt32();
+        var count = data.GetProperty("count").GetInt32();
+        Assert.True(count <= total, $"count ({count}) should not exceed total ({total}).");
+        Assert.Equal(JsonValueKind.Array, data.GetProperty("methods").ValueKind);
+        Assert.Equal(count, data.GetProperty("methods").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task Continuation_token_round_trip_has_no_overlap_and_stable_total()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        await using var client = await ConnectAsync(cts.Token);
+
+        var firstData = Envelope(await CallGetTypeMethods(client, maxItems: 10, continuationToken: null, cts.Token))
+            .GetProperty("data");
+
+        var totalPage1 = firstData.GetProperty("total").GetInt32();
+        Assert.True(totalPage1 > 10, $"System.String should expose more than 10 methods (got {totalPage1}).");
+
+        var nextToken = firstData.GetProperty("nextToken").GetString();
+        Assert.False(string.IsNullOrEmpty(nextToken), "Expected a nextToken when more results remain.");
+
+        var firstSignatures = Signatures(firstData);
+        Assert.Equal(10, firstSignatures.Count);
+
+        var secondData = Envelope(await CallGetTypeMethods(client, maxItems: 10, continuationToken: nextToken, cts.Token))
+            .GetProperty("data");
+
+        Assert.Equal(totalPage1, secondData.GetProperty("total").GetInt32());
+
+        var secondSignatures = Signatures(secondData);
+        Assert.NotEmpty(secondSignatures);
+        Assert.Empty(firstSignatures.Intersect(secondSignatures));
+    }
+
+    [Fact]
+    public async Task Unknown_type_returns_TypeNotFound_error_envelope()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        await using var client = await ConnectAsync(cts.Token);
+
+        var result = await client.CallToolAsync(
+            "get_type_methods",
+            new Dictionary<string, object?>
+            {
+                ["assemblyPath"] = typeof(string).Assembly.Location,
+                ["typeName"] = "No.Such.Type"
+            },
+            cancellationToken: cts.Token);
+
+        Assert.NotEqual(true, result.IsError);
+
+        var envelope = Envelope(result);
+        Assert.Equal("error", envelope.GetProperty("kind").GetString());
+        Assert.Equal("TypeNotFound", envelope.GetProperty("code").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(envelope.GetProperty("message").GetString()));
+    }
+
+    private static async Task<IMcpClient> ConnectAsync(CancellationToken cancellationToken)
+    {
+        Assert.True(File.Exists(ServerDll), $"Expected server DLL at {ServerDll}");
+
+        var transport = new StdioClientTransport(
+            new StdioClientTransportOptions
+            {
+                Command = "dotnet",
+                Arguments = [ServerDll],
+                Name = "sherlock-e2e"
+            },
+            NullLoggerFactory.Instance);
+
+        var options = new McpClientOptions
+        {
+            ClientInfo = new Implementation { Name = "sherlock-e2e-tests", Version = "1.0.0" }
+        };
+
+        return await McpClientFactory.CreateAsync(transport, options, NullLoggerFactory.Instance, cancellationToken);
+    }
+
+    private static async Task<CallToolResult> CallGetTypeMethods(
+        IMcpClient client, int maxItems, string? continuationToken, CancellationToken cancellationToken)
+    {
+        var arguments = new Dictionary<string, object?>
+        {
+            ["assemblyPath"] = typeof(string).Assembly.Location,
+            ["typeName"] = "System.String",
+            ["maxItems"] = maxItems
+        };
+        if (continuationToken != null)
+            arguments["continuationToken"] = continuationToken;
+
+        return await client.CallToolAsync("get_type_methods", arguments, cancellationToken: cancellationToken);
+    }
+
+    private static JsonElement Envelope(CallToolResult result)
+    {
+        var text = result.Content.OfType<TextContentBlock>().Single().Text;
+        using var doc = JsonDocument.Parse(text);
+        return doc.RootElement.Clone();
+    }
+
+    private static HashSet<string> Signatures(JsonElement data) =>
+        data.GetProperty("methods")
+            .EnumerateArray()
+            .Select(m => m.GetProperty("signature").GetString()!)
+            .ToHashSet();
+}

--- a/src/integration-tests/Sherlock.MCP.IntegrationTests.csproj
+++ b/src/integration-tests/Sherlock.MCP.IntegrationTests.csproj
@@ -10,6 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

Adds end-to-end MCP integration tests that launch the built server as a child process over stdio and drive it with the official `ModelContextProtocol` client (`McpClientFactory` + `StdioClientTransport`). This locks in the wire contract as a regression net ahead of the SDK upgrade (#41), which is the explicit blocker noted in the issue.

`src/integration-tests/McpStdioProtocolTests.cs` covers the 5 acceptance criteria:
1. `initialize` handshake succeeds (populated `ServerInfo`).
2. `tools/list` returns the expected tool count and every name is snake_case (asserts `get_type_methods`, `find_implementations_of`, `update_runtime_options`).
3. `tools/call get_type_methods` returns a well-formed envelope (`kind="member.methods"`, `version="1.0.0"`, `count <= total`, `methods` length == `count`).
4. Continuation-token round trip: page 1 → `nextToken` → page 2, disjoint results and stable `total`.
5. Unknown type returns the `{ kind: "error", code: "TypeNotFound" }` envelope (as content, `IsError` false).

### Notes
- **Tool count:** the issue said assert 32, but the server actually registers **36** `[McpServerTool]` methods. The test pins 36 via a named constant with a guidance message on drift; `CLAUDE.md`'s stale "35" is corrected to match.
- **Pagination identity** uses the unique method `signature` (not `name`) since `System.String` has many overloaded methods that share a name.
- Added an explicit `ModelContextProtocol 0.3.0-preview.2` package reference to the test project, pinned to the server's version.

## Test plan
- `dotnet build src/Sherlock.MCP.slnx` — clean (`TreatWarningsAsErrors=true`, 0 warnings).
- `dotnet test src/integration-tests/...` — all 6 tests pass (5 new + existing inotify test) on net10.0 locally. Verified the count-drift guard fails with its guidance message when the constant is wrong.
- CI (`.github/workflows/ci.yml`) runs net8/9/10 on ubuntu.

Closes #40.