### PR TITLE
feat: upgrade ModelContextProtocol SDK to 1.4.0

### DIFF
--- a/src/integration-tests/McpStdioProtocolTests.cs
+++ b/src/integration-tests/McpStdioProtocolTests.cs
@@ -127,7 +127,7 @@ public class McpStdioProtocolTests
         Assert.False(string.IsNullOrWhiteSpace(envelope.GetProperty("message").GetString()));
     }
 
-    private static async Task<IMcpClient> ConnectAsync(CancellationToken cancellationToken)
+    private static async Task<McpClient> ConnectAsync(CancellationToken cancellationToken)
     {
         Assert.True(File.Exists(ServerDll), $"Expected server DLL at {ServerDll}");
 
@@ -145,11 +145,11 @@ public class McpStdioProtocolTests
             ClientInfo = new Implementation { Name = "sherlock-e2e-tests", Version = "1.0.0" }
         };
 
-        return await McpClientFactory.CreateAsync(transport, options, NullLoggerFactory.Instance, cancellationToken);
+        return await McpClient.CreateAsync(transport, options, NullLoggerFactory.Instance, cancellationToken);
     }
 
     private static async Task<CallToolResult> CallGetTypeMethods(
-        IMcpClient client, int maxItems, string? continuationToken, CancellationToken cancellationToken)
+        McpClient client, int maxItems, string? continuationToken, CancellationToken cancellationToken)
     {
         var arguments = new Dictionary<string, object?>
         {

--- a/src/integration-tests/Sherlock.MCP.IntegrationTests.csproj
+++ b/src/integration-tests/Sherlock.MCP.IntegrationTests.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.2" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/server/Sherlock.MCP.Server.csproj
+++ b/src/server/Sherlock.MCP.Server.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
-    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.2" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Upgrades the `ModelContextProtocol` SDK from `0.3.0-preview.2` to the GA **`1.4.0`** release across both the server and the integration-tests project. Closes #41.

The prerequisite called for in the issue — the end-to-end MCP integration tests as a regression net — landed in #51, which unblocked this upgrade.

### Changes
- **Server** (`Sherlock.MCP.Server.csproj`) and **integration-tests** (`Sherlock.MCP.IntegrationTests.csproj`): package bumped to `1.4.0`.
- **`McpStdioProtocolTests.cs`**: the only API break. In 1.x the client types moved to the new `ModelContextProtocol.Core` dependency, where `IMcpClient` is replaced by the abstract class **`McpClient`** and `McpClientFactory.CreateAsync` is now the static **`McpClient.CreateAsync`** (identical parameters). Three references updated.

The server itself required **zero code changes** — `AddMcpServer().WithStdioServerTransport().WithToolsFromAssembly()` and the `[McpServerToolType]`/`[McpServerTool]` attributes are unchanged in 1.x. Breaking changes in the 0.3→1.4 gap (removed `AddXxxFilter` methods, `CallToolResult.StructuredContent` type change, `Tool.Name` required) don't apply: the server uses a DI-injected middleware rather than SDK filters, tests read `TextContentBlock` not `StructuredContent`, and tools are attribute-discovered rather than manually constructed.

## Test plan
- `dotnet build` — clean, **0 warnings** across net8.0/net9.0/net10.0 (warnings-as-errors enforced).
- `dotnet test` — **186/186 passing** on net8.0 and net10.0 (180 unit + 6 integration). net9.0 not run locally (runtime not installed); CI covers it.
- The e2e regression net passes **unchanged**: still 36 tools, all snake_case, envelope/pagination/error-code contracts intact. `ExpectedToolCount = 36` untouched.
- Server smoke test: starts cleanly, `--version` works; live stdio initialize handshake confirmed by the passing `Initialize_handshake_succeeds` test.