### PR TITLE
fix(ci): stop manually url-escaping changelog in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,11 @@ jobs:
           if [ -z "$CHANGELOG" ]; then
             CHANGELOG="Release v$VERSION"
           fi
+          DELIMITER="NOTES_EOF_$(openssl rand -hex 16)"
           {
-            echo "NOTES<<EOF"
-            echo "$CHANGELOG"
-            echo "EOF"
+            echo "NOTES<<$DELIMITER"
+            printf '%s\n' "$CHANGELOG"
+            echo "$DELIMITER"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,13 +63,11 @@ jobs:
           if [ -z "$CHANGELOG" ]; then
             CHANGELOG="Release v$VERSION"
           fi
-          # Escape for GitHub Actions
-          CHANGELOG="${CHANGELOG//'%'/'%25'}"
-          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
-          echo "NOTES<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "NOTES<<EOF"
+            echo "$CHANGELOG"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Problem

The `v2.10.0` GitHub Release body rendered with literal `%0A` (and would have `%25`/`%0D`) escape codes instead of newlines.

## Cause

The **Extract changelog for version** step in `release.yml` manually URL-encoded the changelog:

```bash
CHANGELOG="${CHANGELOG//'%'/'%25'}"
CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
```

That escaping is the legacy `::set-output` convention. The step already writes the value through the `$GITHUB_OUTPUT` `NOTES<<EOF` heredoc, which preserves newlines natively and does **not** decode `%0A`, so the literal codes leaked straight into the release body via `softprops/action-gh-release`.

## Fix

Drop the manual escaping and write the multiline value directly through the heredoc:

```bash
{
  echo "NOTES<<EOF"
  echo "$CHANGELOG"
  echo "EOF"
} >> "$GITHUB_OUTPUT"
```

## Notes

- Affects future releases only. The already-published `v2.10.0` release notes need to be corrected manually (decoded text was provided separately).
- No version bump; CI-only change.