### PR TITLE
feat(server): emit MCP usage instructions and refresh agent docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,9 @@ Since the MCP server runs as a separate process, it cannot access the client's l
 4. **Performance optimization** through pagination, streaming, and response size validation
 
 ### Tool Categories (36 Available)
-- **Assembly Discovery & Analysis** (4 tools): `AnalyzeAssembly`, `GetAssemblyInfo`, `FindAssemblyByClassName`, `FindAssemblyByFileName`
-- **Type Introspection** (7 tools): `GetTypesFromAssembly`, `GetTypeInfo`, `GetTypeHierarchy`, etc.
-- **Member Analysis** (8 tools): `GetTypeMethods`, `GetTypeProperties`, `GetAllTypeMembers`, etc.
+- **Assembly Discovery & Analysis** (5 tools): `AnalyzeAssembly`, `GetAssemblyInfo`, `FindAssemblyByClassName`, `FindAssemblyByFileName`, `FindAssemblyByNugetPackage`
+- **Type Introspection** (7 tools): `GetTypesFromAssembly`, `GetTypeInfo`, `GetTypeHierarchy`, `AnalyzeType`, etc.
+- **Member Analysis** (7 tools): `GetTypeMethods`, `GetTypeProperties`, `GetAllTypeMembers`, `AnalyzeMethod`, etc.
 - **Member Search** (1 tool): `SearchMembers`
 - **Reverse Lookup & IL Analysis** (5 tools): `FindImplementationsOf`, `FindMethodsReturning`, `FindExtensionMethodsFor`, `FindReferencesTo` (supports `analysisDepth='il'` for inbound callers), `GetMethodCalls` (outbound IL call/field analysis)
 - **Attributes & Metadata** (2 tools): `GetMemberAttributes`, `GetParameterAttributes`
@@ -55,38 +55,41 @@ Since the MCP server runs as a separate process, it cannot access the client's l
 - **Caching Layer**: Configurable TTL-based caching for expensive operations
 - **Memory Efficiency**: Streaming and chunked processing for large assemblies
 
-The server uses `Microsoft.Extensions.Hosting` with dependency injection and the latest `ModelContextProtocol.Server` package.
+The server uses `Microsoft.Extensions.Hosting` with dependency injection and the `ModelContextProtocol` 1.4.0 (GA) package.
 
 ## .NET Type Analysis (Sherlock MCP)
 
 This project uses Sherlock MCP for comprehensive .NET assembly analysis. When working with .NET code:
 
+> **Tool names:** the MCP client exposes these tools in `snake_case`, so the names you call are `get_type_methods`, `search_members`, `find_references_to`, etc. The PascalCase names below (`GetTypeMethods`, `SearchMembers`, …) match the C# methods and the tool descriptions — map them to snake_case when invoking.
+
+### Token-efficient by default
+The enumerating tools return a lean **`summary`** payload by default (e.g. `GetTypeMethods` returns `{ name, signature }` — the C# signature already carries the return type, parameters, and modifiers). Only pass `projection='full'` when you need structured access to parameters, attributes, or modifier flags, and ideally only for the specific items you've already narrowed to. Prefer filtered, paginated `GetType*` calls over `GetAllTypeMembers`/`AnalyzeType` on large types — those return everything at once and can blow the token budget. Tools carrying `projection`: `GetTypesFromAssembly`, `GetTypeMethods`, `GetAssemblyInfo`, `GetMethodCalls`, `FindImplementationsOf`, `FindMethodsReturning`, `FindExtensionMethodsFor`, `FindReferencesTo`.
+
 ### Discovery & Initial Analysis
-1. **Find assemblies**: Use `FindAssemblyByClassName` or `FindAssemblyByFileName` when you need to locate DLLs
-2. **Assembly overview**: Start with `AnalyzeAssembly` to get all types and metadata
-3. **Project structure**: Use `AnalyzeProject` and `AnalyzeSolution` for build configuration analysis
+1. **Find the DLL**: `FindAssemblyByClassName` / `FindAssemblyByFileName` when you know a name but not the path; `FindAssemblyByNugetPackage` to resolve a package from the NuGet cache; `GetProjectOutputPaths` from a project file. Don't hardcode `./bin/Debug/net9.0/...` — the target framework varies.
+2. **Orient cheaply**: `GetAssemblyInfo` for identity/target-framework/references (lightweight); `AnalyzeAssembly` when you want the type list with counts.
+3. **Find a member without knowing its type**: `SearchMembers` searches a whole assembly by name fragment (filter with `memberKinds`).
+4. **Project structure**: `AnalyzeProject` and `AnalyzeSolution` for build configuration.
 
 ### Type Analysis Workflow
-1. **List types**: `GetTypesFromAssembly` (paginated) to discover available types
-2. **Type details**: `GetTypeInfo` for basic metadata, inheritance, and accessibility
-3. **Deep analysis**: `AnalyzeType` for comprehensive member overview
+1. **List types**: `GetTypesFromAssembly` (paginated, summary) to discover available types.
+2. **Type details**: `GetTypeInfo` for metadata, inheritance, accessibility, and member counts (lightweight).
+3. **Members**: filtered `GetTypeMethods` / `GetTypeProperties` / `GetTypeFields` / `GetTypeEvents` / `GetTypeConstructors` (use `nameContains` / `hasAttributeContains`); re-call with `projection='full'` for the specific members you need.
 4. **Specialized queries**:
-   - `GetTypeHierarchy` for inheritance chains
-   - `GetGenericTypeInfo` for generic type parameters
-   - `GetNestedTypes` for inner type declarations
+   - `GetTypeHierarchy` for inheritance chains and interfaces — pass `additionalAssemblies` to populate `derivedTypes` (otherwise it returns `null` with a note).
+   - `GetGenericTypeInfo` for generic type parameters and constraints.
+   - `GetNestedTypes` for inner type declarations.
+   - `AnalyzeMethod` for a single method's overloads, parameters, and attributes.
+   - `GetXmlDocsForType` / `GetXmlDocsForMember` for extracted XML documentation.
 
-### Member Analysis (Use appropriate tool for your needs)
-- **All members**: `GetAllTypeMembers` for comprehensive view
-- **Specific categories**: `GetTypeMethods`, `GetTypeProperties`, `GetTypeFields`, `GetTypeEvents`, `GetTypeConstructors`
-- **Method details**: `AnalyzeMethod` for overload analysis with parameters and attributes
-- **Documentation**: `GetXmlDocsForMember` for extracted XML documentation
-
-### Best Practices
-- **Assembly paths**: Typically `./bin/Debug/net9.0/ProjectName.dll` or use discovery tools
-- **Type names**: Prefer full names (`Namespace.Type`) for accuracy
-- **Pagination**: Use `maxItems=50` and `continuationToken` for large results
-- **Filtering**: Leverage `nameContains`, `hasAttributeContains` for targeted queries
-- **Performance**: Check response sizes and use appropriate pagination for large types
+### Relationships & Call Analysis
+- **Who implements / derives**: `FindImplementationsOf` (open-generic match supported).
+- **What returns a type**: `FindMethodsReturning`.
+- **Extension methods for a type**: `FindExtensionMethodsFor`.
+- **Where a type is used**: `FindReferencesTo`; add `analysisDepth='il'` to also resolve inbound callers from method bodies.
+- **What a method calls**: `GetMethodCalls` reads the IL body to list calls and field accesses (use `.ctor`/`.cctor` for constructors).
+- Reverse-lookup tools accept `additionalAssemblies` to widen the search scope across multiple DLLs.
 
 ### Automatic Type Analysis
 
@@ -96,40 +99,40 @@ This project uses Sherlock MCP for comprehensive .NET assembly analysis. When wo
 
 **Discovering unknown types:**
 ```
-1. GetTypesFromAssembly → Find types by name pattern
-2. GetTypeInfo → Get basic metadata and structure
-3. GetTypeMethods/Properties → Analyze specific members
+1. GetTypesFromAssembly → Browse types (summary)
+2. GetTypeInfo → Basic metadata and member counts
+3. GetTypeMethods/Properties (filtered) → Narrow, then projection='full' for detail
 ```
 
-**Understanding inheritance:**
+**Find a member when you don't know the type:**
 ```
-1. GetTypeInfo → Basic type information
-2. GetTypeHierarchy → Full inheritance chain and interfaces
-3. GetGenericTypeInfo → Generic constraints and parameters (if applicable)
+1. SearchMembers nameContains="Parse" memberKinds="method" → Locate the declaring type
+2. GetTypeInfo → Confirm the type
+3. AnalyzeMethod → Inspect overloads and parameters
 ```
 
-**Finding specific functionality:**
+**Understanding inheritance & usage:**
 ```
-1. GetTypeMethods with nameContains="Parse" → Find parsing methods
-2. GetMemberAttributes → Check for specific attributes like [Obsolete]
-3. GetXmlDocsForMember → Get documentation for found methods
+1. GetTypeHierarchy (+ additionalAssemblies) → Inheritance chain, interfaces, derived types
+2. FindImplementationsOf → Concrete implementers
+3. FindReferencesTo analysisDepth='il' → Inbound callers
 ```
 
 **Project exploration:**
 ```
-1. AnalyzeProject → Understand build configuration and dependencies
+1. AnalyzeProject → Build configuration and dependencies
 2. GetProjectOutputPaths → Find compiled assemblies
-3. AnalyzeAssembly → Get overview of available types
+3. GetAssemblyInfo / AnalyzeAssembly → Orient on the assembly
 ```
 
-### Error Handling & Troubleshooting
-- If `TypeNotFound`: Try simple name instead of full name, or use `GetTypesFromAssembly` first
-- If response too large: Use pagination (`maxItems=25`, `skip`, `continuationToken`)
-- For nested types: Use format `OuterType+InnerType` or search via `GetNestedTypes`
-- Missing assembly: Use `FindAssemblyByClassName` or check build output paths
+### Best Practices
+- **Type names**: Prefer full names (`Namespace.Type`) for accuracy.
+- **Start lean**: small `maxItems` + summary projection first; widen `maxItems` or switch to `projection='full'` only when needed. Use `continuationToken` to page large result sets.
+- **Filtering beats fetching**: `nameContains` / `hasAttributeContains` / `memberKinds` rather than retrieving all members.
+- **Stale results**: pass `noCache=true` to bypass the response cache for a single call.
 
-### Performance Tips
-- Cache expensive calls when possible using the built-in caching layer
-- Use targeted filtering rather than retrieving all members
-- Leverage continuation tokens for exploring large result sets
-- Check `totalCount` fields to understand data size before requesting all results
+### Error Handling & Troubleshooting
+- If `TypeNotFound`: try the simple name instead of the full name, or `GetTypesFromAssembly` / `SearchMembers` to find it first.
+- If response too large: reduce `maxItems`, keep `projection='summary'`, and page with `continuationToken`.
+- For nested types: use format `OuterType+InnerType` or `GetNestedTypes`.
+- Missing assembly: use `FindAssemblyByClassName` / `FindAssemblyByNugetPackage` or check build output paths via `GetProjectOutputPaths`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,7 +21,7 @@ The project is organized into the following components:
 - **C#**: The primary programming language used.
 - **xUnit**: The framework used for unit tests.
 - **Microsoft.Extensions.Hosting**: Used for hosting the server.
-- **ModelContextProtocol**: The library used for MCP communication.
+- **ModelContextProtocol 1.4.0 (GA)**: The library used for MCP communication.
 - **System.Reflection / AssemblyLoadContext**: Used for assembly inspection and controlled loading.
 
 ## Development Workflow
@@ -49,6 +49,21 @@ To run the unit tests, use the following command:
 ```bash
 dotnet test src/unit-tests/Sherlock.MCP.Tests.csproj
 ```
+
+## Using the Sherlock Tools
+
+When analyzing .NET code, prefer the Sherlock MCP tools over guessing about APIs. The server exposes **36 tools** across nine categories: Assembly Discovery, Type Introspection, Member Analysis, Member Search, Reverse Lookup, IL Analysis, Attributes & Metadata, XML Documentation, and Project Analysis.
+
+> **Tool names:** MCP clients call these tools in `snake_case` — the PascalCase names below (`GetTypeMethods`, `SearchMembers`, …) match the C# methods, but you invoke them as `get_type_methods`, `search_members`, and so on.
+
+Work **narrow → wide** to stay within the token budget:
+
+1. **Locate the DLL** with `FindAssemblyByClassName`, `FindAssemblyByFileName`, `FindAssemblyByNugetPackage`, or `GetProjectOutputPaths` — don't hardcode `bin/Debug/<tfm>/*.dll`.
+2. **Find the type**: `SearchMembers` when you know a member name but not its type; otherwise `GetTypesFromAssembly`, then `GetTypeInfo`.
+3. **Inspect members**: filtered `GetTypeMethods` / `GetTypeProperties` (use `nameContains`, `hasAttributeContains`). These default to a lean **`summary`** projection — pass `projection='full'` only when you need parameters, attributes, or modifier flags, and avoid `GetAllTypeMembers` / `AnalyzeType` on large types.
+4. **Trace relationships**: `FindImplementationsOf`, `FindMethodsReturning`, `FindExtensionMethodsFor`, `FindReferencesTo` (add `analysisDepth='il'` for inbound callers), and `GetMethodCalls` (what a method body calls).
+
+Always pass the assembly path and prefer full type names (`Namespace.Type`). See the project README's "Tools Overview" for the full catalog and parameter reference.
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This tool is essential for developers who want to harness LLM capabilities for:
 ## What's New in 2.10.0
 
 - **New tools**: `SearchMembers` (assembly-wide member search), `FindExtensionMethodsFor`, `GetMethodCalls` (IL-level "what does this method call?"), and `FindAssemblyByNugetPackage`.
-- **Token-efficient projections**: enumerating tools now default to a lean `summary` and accept `projection='full'` for structured detail — see [Response Shape](#tools-overview).
+- **Token-efficient projections**: enumerating tools now default to a lean `summary` and accept `projection='full'` for structured detail — see [Response Shape](#response-shape-token-efficiency).
 - **IL analysis**: `FindReferencesTo` accepts `analysisDepth='il'` to resolve inbound callers from method bodies.
 - **Wider scope**: `GetTypeHierarchy` and reverse-lookup tools accept `additionalAssemblies` (derived types are computed only when provided).
 - **SDK upgrade**: `ModelContextProtocol` `0.3.0-preview.2` → `1.4.0` (GA). See `CHANGELOG.md` for full details.
@@ -239,7 +239,7 @@ All member analysis tools support comprehensive filtering and pagination:
 * `continuationToken` (string): Token-based pagination for large datasets
 * `sortBy` / `sortOrder` (string): Sort by name/access in asc/desc order
 
-**Response Shape (token efficiency):**
+#### Response Shape (token efficiency)
 
 Most enumerating tools default to a lean **`summary`** projection and let you opt into the heavier **`full`** payload only when you need it. Reach for `full` deliberately — `summary` is usually enough to decide your next call.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ This tool is essential for developers who want to harness LLM capabilities for:
 *   **Stable JSON API**: Consistent envelopes with versioning and structured error codes
 *   **.NET 9.0 Native**: Built on the latest .NET platform with modern C# features
 *   **Project Integration**: Solution and project file analysis with dependency resolution
+*   **Current MCP SDK**: Built on `ModelContextProtocol` 1.4.0 (GA)
+
+## What's New in 2.10.0
+
+- **New tools**: `SearchMembers` (assembly-wide member search), `FindExtensionMethodsFor`, `GetMethodCalls` (IL-level "what does this method call?"), and `FindAssemblyByNugetPackage`.
+- **Token-efficient projections**: enumerating tools now default to a lean `summary` and accept `projection='full'` for structured detail — see [Response Shape](#tools-overview).
+- **IL analysis**: `FindReferencesTo` accepts `analysisDepth='il'` to resolve inbound callers from method bodies.
+- **Wider scope**: `GetTypeHierarchy` and reverse-lookup tools accept `additionalAssemblies` (derived types are computed only when provided).
+- **SDK upgrade**: `ModelContextProtocol` `0.3.0-preview.2` → `1.4.0` (GA). See `CHANGELOG.md` for full details.
 
 ## Installation
 
@@ -57,46 +66,52 @@ No arguments are required. The server self-registers all tools when launched.
 
 ## Auto-Configure for .NET Projects
 
-To automatically use Sherlock when working with .NET code, add these configurations:
+**You usually don't need to paste anything.** Sherlock ships its usage guidance in the MCP `instructions` field returned at initialize, and most MCP clients (including Claude Code) surface that to the agent automatically — so the guidance stays correct and versioned with the package, with no copy-paste to maintain.
+
+The snippets below are **optional reinforcement**. Keep them short and principle-based rather than enumerating tool names and workflows: a static list pasted into your repo will drift as Sherlock's tools evolve, whereas the tools' own descriptions (and the server `instructions`) always match the version you're running.
+
+> Tool names are exposed in `snake_case` (`get_type_methods`, `search_members`, …); argument names stay camelCase (`projection`, `nameContains`).
 
 ### Claude Code (CLAUDE.md)
 
-Add this to your project's `CLAUDE.md` file:
+Optional — a short pointer in your project's `CLAUDE.md`:
 
 ```markdown
 ## .NET Assembly Analysis
 
-This project uses Sherlock MCP for .NET assembly analysis. When analyzing .NET types, methods, or assemblies:
-
-1. Use sherlock-mcp tools instead of guessing about .NET APIs
-2. For type analysis: `GetTypeInfo`, `GetTypeMethods`, `GetTypeProperties`
-3. For assembly overview: `AnalyzeAssembly` or `GetTypesFromAssembly`
-4. For project structure: `AnalyzeProject`, `AnalyzeSolution`
-5. Assembly paths are typically: `./bin/Debug/net9.0/ProjectName.dll`
-
-Always include assembly path, prefer full type names, and use pagination for large results.
+Use the Sherlock MCP tools (`get_type_methods`, `search_members`, …) for .NET type/assembly
+questions instead of guessing. Locate DLLs with the `find_assembly_by_*` / `get_project_output_paths`
+tools rather than hardcoding bin paths. Start lean — `search_members` or `get_types_from_assembly`,
+then drill in — and pass `projection='full'` only when you need parameters/attributes/modifiers.
+The tools' own descriptions cover the specifics.
 ```
 
-### Cursor (.cursorrules)
+### Cursor (.cursor/rules)
 
-Add this to your project's `.cursorrules` file:
+The single-file `.cursorrules` format is **deprecated** (and silently ignored in Cursor's Agent mode).
+Add a Project Rule at `.cursor/rules/sherlock.mdc` instead:
 
+```mdc
+---
+description: Use Sherlock MCP for .NET assembly/type analysis
+alwaysApply: true
+---
+
+- Prefer the Sherlock MCP tools (snake_case, e.g. `get_type_methods`, `search_members`) over guessing about .NET APIs.
+- Find DLLs with `find_assembly_by_*` / `get_project_output_paths`; don't hardcode `bin/Debug/<tfm>/*.dll`.
+- Start lean (`search_members` / `get_types_from_assembly`); request `projection='full'` only when you need parameters/attributes/modifiers.
 ```
-# .NET Analysis Rules
-When working with .NET code, assemblies, or types:
-- Use sherlock-mcp tools for accurate type/member information
-- Assembly paths: ./bin/Debug/net9.0/*.dll or ./bin/Release/net9.0/*.dll
-- For unknown types: GetTypesFromAssembly -> GetTypeInfo -> GetTypeMethods/Properties
-- For code analysis: AnalyzeAssembly for overview, GetTypeInfo for details
-- Use pagination (maxItems=50) for large results to avoid token limits
-```
 
-### Global Configuration
+### Other agents (AGENTS.md)
 
-For system-wide usage, add to your global Claude Code settings or Cursor configuration:
+For tools that follow the cross-editor `AGENTS.md` convention, the same short pointer works — drop the Claude Code snippet above into your `AGENTS.md`.
+
+### Global configuration
+
+For system-wide usage, add to your global agent settings:
 
 ```text
-For .NET development: Use sherlock-mcp tools when analyzing assemblies, types, methods, or project structure. Prefer these over guessing .NET API details.
+For .NET work, use the Sherlock MCP tools (snake_case) to analyze assemblies, types, and members instead of guessing. Start lean and opt into projection='full' only when you need detail.
 ```
 
 ## How To Prompt It
@@ -135,13 +150,28 @@ Tune paging and filters
 Use GetTypeMethods on /abs/path/MyLib.dll, type MyNamespace.MyType, sortBy name, sortOrder asc, skip 0, take 25, hasAttributeContains Obsolete.
 ```
 
+Browse lean, then get detail (projection)
+
+```text
+On /abs/path/MyLib.dll, run GetTypeMethods for MyNamespace.MyType with the default summary projection to see signatures. Then re-call GetTypeMethods with projection='full' only for the methods I name to get their parameters and attributes.
+```
+
+Trace relationships and call sites
+
+```text
+On /abs/path/MyLib.dll: FindImplementationsOf MyNamespace.IMyService. Then FindReferencesTo that interface with analysisDepth='il' to find callers, and GetMethodCalls on the most relevant method to see what it invokes.
+```
+
 ## Tools Overview
+
+> **Tool names:** MCP clients call these tools in `snake_case` — `GetTypeMethods` → `get_type_methods`, `SearchMembers` → `search_members`, and so on. The PascalCase names used throughout this README match the underlying C# methods and the tool descriptions your client displays.
 
 ### Assembly Discovery & Analysis
 - **`AnalyzeAssembly`**: Complete assembly overview with public types and metadata
 - **`GetAssemblyInfo`**: Assembly-level metadata — identity/version, target framework, and referenced assemblies (`projection=full` adds all assembly attributes)
 - **`FindAssemblyByClassName`**: Locate assemblies containing specific class names
 - **`FindAssemblyByFileName`**: Find assemblies by file name in common build paths
+- **`FindAssemblyByNugetPackage`**: Resolve a DLL from the local NuGet cache by package id (optional `version`/`tfm`)
 
 ### Type Introspection
 - **`GetTypesFromAssembly`**: List all public types with metadata (paginated)
@@ -161,10 +191,17 @@ Use GetTypeMethods on /abs/path/MyLib.dll, type MyNamespace.MyType, sortBy name,
 - **`GetTypeConstructors`**: Constructor signatures and parameters
 - **`AnalyzeMethod`**: Deep method analysis with overloads and attributes
 
+### Member Search
+- **`SearchMembers`**: Search a whole assembly for members whose name contains a fragment — the entry point when you know a member name but not its declaring type. Filter by `memberKinds` (`method|property|field|event|type`).
+
 ### Reverse Lookup
-- **`FindImplementationsOf`**: Types implementing an interface or deriving from a base class
+- **`FindImplementationsOf`**: Types implementing an interface or deriving from a base class (open-generic match supported)
 - **`FindMethodsReturning`**: Methods whose return type matches a given type (open-generic match supported)
-- **`FindReferencesTo`**: Broader sweep across parameters, fields, properties, events, and generic arguments
+- **`FindExtensionMethodsFor`**: Extension methods that extend a given type (scans static classes by `this`-parameter)
+- **`FindReferencesTo`**: Broader sweep across parameters, fields, properties, events, and generic arguments; pass `analysisDepth='il'` to also resolve inbound callers from method bodies
+
+### IL Analysis
+- **`GetMethodCalls`**: Read a method's IL body to list what it calls and which fields it touches — the "what does this method do?" question signature-level tools can't answer (aggregates across overloads; use `.ctor`/`.cctor` for constructors)
 
 ### Attributes & Metadata
 - **`GetMemberAttributes`**: Attributes for specific members
@@ -198,9 +235,18 @@ All member analysis tools support comprehensive filtering and pagination:
 
 **Pagination:**
 * `skip` / `take` (int): Standard offset pagination
-* `maxItems` (int): Maximum results per request
+* `maxItems` (int): Maximum results per request (default 50; `FindReferencesTo` defaults to 25)
 * `continuationToken` (string): Token-based pagination for large datasets
 * `sortBy` / `sortOrder` (string): Sort by name/access in asc/desc order
+
+**Response Shape (token efficiency):**
+
+Most enumerating tools default to a lean **`summary`** projection and let you opt into the heavier **`full`** payload only when you need it. Reach for `full` deliberately — `summary` is usually enough to decide your next call.
+
+* `projection` (`summary` | `full`): supported by `GetTypesFromAssembly`, `GetTypeMethods`, `GetAssemblyInfo`, `GetMethodCalls`, `FindImplementationsOf`, `FindMethodsReturning`, `FindExtensionMethodsFor`, and `FindReferencesTo`. `summary` returns just enough to browse (e.g. `{ name, signature }` for methods); `full` adds structured fields (parameters, attributes, return type, modifiers, etc.). _Note: `GetTypeProperties/Fields/Events/Constructors` have a single fixed shape and take no `projection`._
+* `analysisDepth` (`signatures` | `il`): `FindReferencesTo` only. `signatures` (default) scans member declarations; `il` additionally scans method bodies for inbound callers (slower).
+* `additionalAssemblies` (string[]): widen the search scope for `GetTypeHierarchy` and the reverse-lookup tools. `GetTypeHierarchy.derivedTypes` stays `null` until you pass this.
+* `noCache` (bool): bypass the response cache for a single call when you suspect stale results.
 
 **Type Resolution:**
 * Supports full names (`Namespace.Type`), simple names (`Type`), and nested types (`Outer+Inner`)

--- a/src/integration-tests/McpStdioProtocolTests.cs
+++ b/src/integration-tests/McpStdioProtocolTests.cs
@@ -25,6 +25,19 @@ public class McpStdioProtocolTests
     }
 
     [Fact]
+    public async Task Initialize_exposes_server_usage_instructions()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        await using var client = await ConnectAsync(cts.Token);
+
+        Assert.False(
+            string.IsNullOrWhiteSpace(client.ServerInstructions),
+            "Server should return MCP instructions so clients can surface usage guidance automatically.");
+        Assert.Contains("search_members", client.ServerInstructions);
+        Assert.Contains("projection", client.ServerInstructions);
+    }
+
+    [Fact]
     public async Task Tools_list_returns_expected_count_and_snake_case_names()
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));

--- a/src/runtime/README_MemberAnalysis.md
+++ b/src/runtime/README_MemberAnalysis.md
@@ -138,6 +138,8 @@ The service is integrated with MCP (Model Context Protocol) tools:
 5. **GetTypeConstructors**: Analyze all constructors in a type
 6. **GetAllTypeMembers**: Comprehensive analysis of all member types
 
+> These six are the member-analysis tools backed by this service. They are part of a larger surface of **36 MCP tools** — see the project README's "Tools Overview" for the full catalog (type introspection, member search, reverse lookup, IL analysis, XML docs, and project analysis).
+
 ### Tool Parameters
 
 All tools support filtering options:
@@ -145,6 +147,8 @@ All tools support filtering options:
 - `includeNonPublic`: Include non-public members (default: false)
 - `includeStatic`: Include static members (default: true)
 - `includeInstance`: Include instance members (default: true)
+
+`GetTypeMethods` additionally supports `projection`: it returns a lean `summary` (`{ name, signature }`) by default and accepts `projection='full'` to add `parameters[]`, `attributes`, `returnType`, and modifier flags. Most member tools also support `nameContains` / `hasAttributeContains` filtering, `maxItems` / `continuationToken` pagination, and `noCache`.
 
 ## Usage Examples
 
@@ -174,7 +178,7 @@ The tools are automatically registered and available through the MCP server. The
 
 ## Assembly Loading
 
-The service uses `Assembly.LoadFrom()` and maintains a cache of loaded assemblies to avoid repeated loading. It supports:
+The service loads assemblies into a dedicated `AssemblyLoadContext` (via `LoadFromAssemblyPath`, with a `MetadataLoadContext` for metadata-only inspection) and maintains an mtime-aware cache of loaded assemblies to avoid repeated loading. It supports:
 - Full assembly paths
 - Type name resolution by both full name and simple name
 - Error handling for missing assemblies or types

--- a/src/server/Program.cs
+++ b/src/server/Program.cs
@@ -33,7 +33,7 @@ const string serverInstructions =
 
     Locate the assembly first with find_assembly_by_class_name, find_assembly_by_file_name, find_assembly_by_nuget_package, or get_project_output_paths rather than hardcoding bin/Debug/<tfm> paths (the target framework varies).
 
-    Work narrow-to-wide and stay token-lean: use search_members when you know a member name but not its declaring type, or get_types_from_assembly to browse; then get_type_info; then filtered get_type_methods / get_type_properties (nameContains, hasAttributeContains). Enumerating tools return a lean 'summary' by default - pass projection='full' only when you need parameters, attributes, or modifiers, and avoid get_all_type_members / analyze_type on large types.
+    Work narrow-to-wide and stay token-lean: use search_members when you know a member name but not its declaring type, or get_types_from_assembly to browse; then get_type_info; then filtered get_type_methods / get_type_properties (nameContains, hasAttributeContains). get_type_methods returns a lean 'summary' by default - pass projection='full' only when you need parameters, attributes, or modifiers (get_type_properties / get_type_fields / get_type_events / get_type_constructors have a single fixed shape and take no projection). Avoid get_all_type_members / analyze_type on large types.
 
     For relationships use find_implementations_of, find_methods_returning, find_extension_methods_for, and find_references_to (set analysisDepth='il' to resolve inbound callers); use get_method_calls to see what a method body invokes.
 

--- a/src/server/Program.cs
+++ b/src/server/Program.cs
@@ -27,6 +27,19 @@ builder.Logging.AddConsole(consoleLogOptions =>
     consoleLogOptions.LogToStandardErrorThreshold = LogLevel.Trace;
 });
 
+const string serverInstructions =
+    """
+    Sherlock provides .NET assembly introspection via reflection. Prefer these tools over guessing about .NET APIs.
+
+    Locate the assembly first with find_assembly_by_class_name, find_assembly_by_file_name, find_assembly_by_nuget_package, or get_project_output_paths rather than hardcoding bin/Debug/<tfm> paths (the target framework varies).
+
+    Work narrow-to-wide and stay token-lean: use search_members when you know a member name but not its declaring type, or get_types_from_assembly to browse; then get_type_info; then filtered get_type_methods / get_type_properties (nameContains, hasAttributeContains). Enumerating tools return a lean 'summary' by default - pass projection='full' only when you need parameters, attributes, or modifiers, and avoid get_all_type_members / analyze_type on large types.
+
+    For relationships use find_implementations_of, find_methods_returning, find_extension_methods_for, and find_references_to (set analysisDepth='il' to resolve inbound callers); use get_method_calls to see what a method body invokes.
+
+    Prefer full type names (Namespace.Type). Tool names are snake_case; argument names are camelCase.
+    """;
+
 builder.Services
     .AddSingleton<RuntimeOptions>()
     .AddSingleton<IInspectionContextProvider, SharedInspectionContextProvider>()
@@ -41,7 +54,7 @@ builder.Services
     .AddSingleton<IIlAnalysisService, IlAnalysisService>()
     .AddSingleton<ISearchService, SearchService>()
     .AddSingleton<ToolMiddleware>()
-    .AddMcpServer()
+    .AddMcpServer(options => options.ServerInstructions = serverInstructions)
     .WithStdioServerTransport()
     .WithToolsFromAssembly();
 


### PR DESCRIPTION
## Summary

Brings the documentation back in line with the current 36-tool surface (v2.9.0–v2.10.0) and, more importantly, fixes *how* consumers instruct their agents to use Sherlock.

**Server change — guidance ships with the package:**
- Populate the MCP `instructions` field at initialize (`McpServerOptions.ServerInstructions` in `Program.cs`). Connected clients now surface Sherlock's lean-workflow guidance automatically, versioned with the package — no copy-paste that drifts.

**Docs refresh — accuracy:**
- README "Tools Overview" was missing the 4 newest tools (`SearchMembers`, `FindExtensionMethodsFor`, `GetMethodCalls`, `FindAssemblyByNugetPackage`) while claiming 36; now complete and reorganized into the real 9 categories.
- Documented the previously-undocumented `projection` (summary/full), `analysisDepth='il'`, `additionalAssemblies`, and `noCache` params — verified against the actual tool signatures (e.g. `GetTypeProperties/Fields/Events/Constructors` take no `projection`).
- Added a "What's New in 2.10.0" blurb and SDK 1.4.0 note; corrected the runtime README's stale `Assembly.LoadFrom()` claim to `AssemblyLoadContext`; fixed CLAUDE.md tool-count math.

**Consumer guidance — current best practice:**
- Restructured the "Auto-Configure" section to lead with the server-provided `instructions` (consumers usually need to paste nothing).
- Replaced the deprecated `.cursorrules` recommendation (silently ignored in Cursor Agent mode) with a `.cursor/rules/sherlock.mdc` Project Rule; added an `AGENTS.md` option.
- Slimmed the pasted snippets to principle-based pointers so they don't drift as tools evolve.
- Added a snake_case note across agent-facing docs (the wire names are `get_type_methods`, etc., not the PascalCase used in prose).

## Test plan

- [x] `dotnet build src/Sherlock.MCP.slnx` — clean (0 warnings)
- [x] Integration tests pass on net8.0 and net10.0 (net9.0 runtime not installed locally), including the new `Initialize_exposes_server_usage_instructions`
- [x] Verified live over stdio: `instructions` now present in the initialize response; `search_members` and `get_type_methods` (projection summary vs full) return the documented shapes
- [x] Cross-checked all 36 tool names appear in the README Tools Overview