### PR TITLE
feat(runtime): resolve transitive NuGet dependencies and surface resolution failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-06-21
+
+### Added
+
+- Transitive dependency resolution from the NuGet global packages cache. When an assembly is loaded from an isolated `lib/<tfm>` folder (e.g. `~/.nuget/packages/.../lib/net8.0/`) whose dependencies are not sitting alongside it, the loader now probes the cache for the best framework-compatible build of each dependency package. This makes type introspection work against bare NuGet assemblies (such as `Azure.ResourceManager.MachineLearning`) without needing a build output directory.
+- `GetTypesFromAssembly` now accepts an optional `additionalAssemblies` parameter so callers can point at sibling dependency DLLs (e.g. a `bin/Debug/<tfm>` folder) to resolve types when automatic probing is insufficient.
+
+### Fixed
+
+- `GetTypesFromAssembly` no longer returns a silent empty result when an assembly's dependencies cannot be resolved. It now reports a structured `DependencyResolutionFailed` error naming the unresolved assemblies and how to supply them, instead of masking the failure behind an empty list.
+
 ## [2.11.0] - 2026-06-12
 
 ### Added

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/jcucci/dotnet-sherlock-mcp",
     "source": "github"
   },
-  "version": "2.11.0",
+  "version": "2.12.0",
   "packages": [
     {
       "registryType": "nuget",
       "identifier": "Sherlock.MCP.Server",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/runtime/DependencyResolutionException.cs
+++ b/src/runtime/DependencyResolutionException.cs
@@ -1,0 +1,18 @@
+namespace Sherlock.MCP.Runtime;
+
+public sealed class DependencyResolutionException : Exception
+{
+    public DependencyResolutionException(string assemblyPath, IReadOnlyList<string> unresolvedDependencies)
+        : base(BuildMessage(assemblyPath, unresolvedDependencies))
+    {
+        AssemblyPath = assemblyPath;
+        UnresolvedDependencies = unresolvedDependencies;
+    }
+
+    public string AssemblyPath { get; }
+
+    public IReadOnlyList<string> UnresolvedDependencies { get; }
+
+    private static string BuildMessage(string assemblyPath, IReadOnlyList<string> unresolved) =>
+        $"Could not resolve dependencies for '{Path.GetFileName(assemblyPath)}': {string.Join(", ", unresolved)}.";
+}

--- a/src/runtime/ITypeAnalysisService.cs
+++ b/src/runtime/ITypeAnalysisService.cs
@@ -19,6 +19,6 @@ public interface ITypeAnalysisService
     public (string TypeFullName, TypeAnalysisAttributeInfo[] Attributes)? GetTypeAttributes(string assemblyPath, string typeName);
     public TypeAnalysisInfo[] GetNestedTypes(Type parentType);
     public (string TypeFullName, TypeAnalysisInfo[] NestedTypes)? GetNestedTypes(string assemblyPath, string typeName);
-    public TypeAnalysisInfo[] GetTypesFromAssembly(string assemblyPath);
+    public TypeAnalysisInfo[] GetTypesFromAssembly(string assemblyPath, IReadOnlyList<string>? additionalSearchDirectories = null);
 }
 

--- a/src/runtime/Inspection/DependencyDiagnostics.cs
+++ b/src/runtime/Inspection/DependencyDiagnostics.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+
+namespace Sherlock.MCP.Runtime.Inspection;
+
+internal static class DependencyDiagnostics
+{
+    public static string[] ExtractUnresolved(ReflectionTypeLoadException ex)
+    {
+        var names = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var loaderException in ex.LoaderExceptions)
+        {
+            var name = ExtractAssemblyName(loaderException);
+            if (!string.IsNullOrWhiteSpace(name)) names.Add(name);
+        }
+        return names.ToArray();
+    }
+
+    public static string? ExtractUnresolved(Exception ex) => ExtractAssemblyName(ex);
+
+    private static string? ExtractAssemblyName(Exception? loaderException) =>
+        loaderException switch
+        {
+            FileNotFoundException fnf => ToSimpleName(NameFrom(fnf.FileName, fnf.Message)),
+            FileLoadException fle => ToSimpleName(NameFrom(fle.FileName, fle.Message)),
+            _ => null
+        };
+
+    private static string NameFrom(string? fileName, string? message)
+    {
+        if (!string.IsNullOrWhiteSpace(fileName)) return fileName;
+        if (string.IsNullOrWhiteSpace(message)) return "";
+        var start = message.IndexOf('\'');
+        var end = start >= 0 ? message.IndexOf('\'', start + 1) : -1;
+        return start >= 0 && end > start ? message[(start + 1)..end] : "";
+    }
+
+    private static string? ToSimpleName(string assemblyDisplayName)
+    {
+        if (string.IsNullOrWhiteSpace(assemblyDisplayName)) return null;
+        var comma = assemblyDisplayName.IndexOf(',');
+        var name = comma >= 0 ? assemblyDisplayName[..comma] : assemblyDisplayName;
+        return name.Trim();
+    }
+}

--- a/src/runtime/Inspection/DependencyResolvingLoadContext.cs
+++ b/src/runtime/Inspection/DependencyResolvingLoadContext.cs
@@ -8,11 +8,19 @@ public sealed class DependencyResolvingLoadContext : AssemblyLoadContext, IDispo
 {
     private readonly string _baseDirectory;
     private readonly ConcurrentDictionary<string, Assembly> _loadedAssemblies = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string> _additionalFiles = new(StringComparer.OrdinalIgnoreCase);
 
-    public DependencyResolvingLoadContext(string name, string baseDirectory)
+    public DependencyResolvingLoadContext(string name, string baseDirectory, IEnumerable<string>? additionalAssemblyFiles = null)
         : base(name, isCollectible: true)
     {
         _baseDirectory = baseDirectory;
+        if (additionalAssemblyFiles != null)
+            foreach (var file in additionalAssemblyFiles)
+            {
+                var simpleName = Path.GetFileNameWithoutExtension(file);
+                if (!string.IsNullOrEmpty(simpleName) && !_additionalFiles.ContainsKey(simpleName))
+                    _additionalFiles[simpleName] = file;
+            }
         Resolving += OnResolving;
     }
 
@@ -30,7 +38,7 @@ public sealed class DependencyResolvingLoadContext : AssemblyLoadContext, IDispo
         if (_loadedAssemblies.TryGetValue(name.Name, out var cached))
             return cached;
 
-        var assemblyPath = FindAssemblyInDirectory(name);
+        var assemblyPath = FindAssemblyInDirectory(name) ?? FindInAdditionalFiles(name);
         if (assemblyPath == null)
             return null;
 
@@ -60,5 +68,11 @@ public sealed class DependencyResolvingLoadContext : AssemblyLoadContext, IDispo
             return exePath;
 
         return null;
+    }
+
+    private string? FindInAdditionalFiles(AssemblyName name)
+    {
+        if (string.IsNullOrEmpty(name.Name)) return null;
+        return _additionalFiles.TryGetValue(name.Name, out var path) && File.Exists(path) ? path : null;
     }
 }

--- a/src/runtime/Inspection/IAssemblyInspectionContext.cs
+++ b/src/runtime/Inspection/IAssemblyInspectionContext.cs
@@ -6,6 +6,8 @@ public interface IAssemblyInspectionContext : IDisposable
 {
     Assembly Assembly { get; }
 
+    IReadOnlyList<string> UnresolvedDependencies { get; }
+
     IEnumerable<Type> GetTypes();
 
     MemberInfo[] GetMembers(Type type, BindingFlags flags);

--- a/src/runtime/Inspection/IInspectionContextProvider.cs
+++ b/src/runtime/Inspection/IInspectionContextProvider.cs
@@ -4,7 +4,7 @@ namespace Sherlock.MCP.Runtime.Inspection;
 
 public interface IInspectionContextProvider
 {
-    InspectionContextLease Acquire(string assemblyPath, bool forceRuntimeLoad = false);
+    InspectionContextLease Acquire(string assemblyPath, bool forceRuntimeLoad = false, IReadOnlyList<string>? additionalSearchDirectories = null);
 }
 
 public sealed class InspectionContextLease : IDisposable

--- a/src/runtime/Inspection/InspectionContextFactory.cs
+++ b/src/runtime/Inspection/InspectionContextFactory.cs
@@ -2,14 +2,14 @@ namespace Sherlock.MCP.Runtime.Inspection;
 
 public static class InspectionContextFactory
 {
-    public static IAssemblyInspectionContext Create(string assemblyPath, bool forceRuntimeLoad = false)
+    public static IAssemblyInspectionContext Create(string assemblyPath, bool forceRuntimeLoad = false, IReadOnlyList<string>? additionalSearchDirectories = null)
     {
         if (forceRuntimeLoad)
         {
-            return new IsolatedRuntimeInspectionContext(assemblyPath);
+            return new IsolatedRuntimeInspectionContext(assemblyPath, additionalSearchDirectories);
         }
 
-        return new MetadataOnlyInspectionContext(assemblyPath);
+        return new MetadataOnlyInspectionContext(assemblyPath, additionalSearchDirectories);
     }
 }
 

--- a/src/runtime/Inspection/IsolatedRuntimeInspectionContext.cs
+++ b/src/runtime/Inspection/IsolatedRuntimeInspectionContext.cs
@@ -5,17 +5,20 @@ namespace Sherlock.MCP.Runtime.Inspection;
 public sealed class IsolatedRuntimeInspectionContext : IAssemblyInspectionContext
 {
     private readonly DependencyResolvingLoadContext _alc;
+    private string[] _unresolvedDependencies = [];
 
-    public IsolatedRuntimeInspectionContext(string assemblyPath)
+    public IsolatedRuntimeInspectionContext(string assemblyPath, IReadOnlyList<string>? additionalSearchDirectories = null)
     {
         var assemblyDirectory = Path.GetDirectoryName(assemblyPath) ?? ".";
         var contextName = $"sherlock_{Path.GetFileNameWithoutExtension(assemblyPath)}_{Guid.NewGuid():N}";
 
-        _alc = new DependencyResolvingLoadContext(contextName, assemblyDirectory);
+        _alc = new DependencyResolvingLoadContext(contextName, assemblyDirectory, BuildProbeFiles(assemblyPath, additionalSearchDirectories));
         Assembly = _alc.LoadFromAssemblyPath(Path.GetFullPath(assemblyPath));
     }
 
     public Assembly Assembly { get; }
+
+    public IReadOnlyList<string> UnresolvedDependencies => _unresolvedDependencies;
 
     public IEnumerable<Type> GetTypes()
     {
@@ -25,7 +28,36 @@ public sealed class IsolatedRuntimeInspectionContext : IAssemblyInspectionContex
         }
         catch (ReflectionTypeLoadException ex)
         {
+            _unresolvedDependencies = DependencyDiagnostics.ExtractUnresolved(ex);
             return ex.Types.Where(t => t != null).Cast<Type>();
+        }
+    }
+
+    private static List<string> BuildProbeFiles(string assemblyPath, IReadOnlyList<string>? additionalSearchDirectories)
+    {
+        var files = new List<string>();
+        if (additionalSearchDirectories != null)
+            foreach (var directory in additionalSearchDirectories)
+                files.AddRange(SafeEnumerateDlls(directory));
+
+        var fullPath = Path.GetFullPath(assemblyPath);
+        if (NuGetCacheProbe.TryParseCacheLayout(fullPath, out var consumingTfm, out var packageId))
+            files.AddRange(NuGetCacheProbe.EnumerateCandidateDependencyDlls(consumingTfm, packageId));
+
+        return files;
+    }
+
+    private static string[] SafeEnumerateDlls(string directory)
+    {
+        try
+        {
+            return Directory.Exists(directory)
+                ? Directory.GetFiles(directory, "*.dll", SearchOption.TopDirectoryOnly)
+                : [];
+        }
+        catch
+        {
+            return [];
         }
     }
 

--- a/src/runtime/Inspection/MetadataOnlyInspectionContext.cs
+++ b/src/runtime/Inspection/MetadataOnlyInspectionContext.cs
@@ -5,16 +5,19 @@ namespace Sherlock.MCP.Runtime.Inspection;
 public sealed class MetadataOnlyInspectionContext : IAssemblyInspectionContext
 {
     private readonly MetadataLoadContext _mlc;
+    private string[] _unresolvedDependencies = [];
 
-    public MetadataOnlyInspectionContext(string assemblyPath)
+    public MetadataOnlyInspectionContext(string assemblyPath, IReadOnlyList<string>? additionalSearchDirectories = null)
     {
-        var resolver = MetadataResolverFactory.Create(assemblyPath);
+        var resolver = MetadataResolverFactory.Create(assemblyPath, additionalSearchDirectories);
         var coreAssemblyName = typeof(object).Assembly.GetName().Name;
         _mlc = new MetadataLoadContext(resolver, coreAssemblyName);
         Assembly = _mlc.LoadFromAssemblyPath(Path.GetFullPath(assemblyPath));
     }
 
     public Assembly Assembly { get; }
+
+    public IReadOnlyList<string> UnresolvedDependencies => _unresolvedDependencies;
 
     public IEnumerable<Type> GetTypes()
     {
@@ -24,6 +27,7 @@ public sealed class MetadataOnlyInspectionContext : IAssemblyInspectionContext
         }
         catch (ReflectionTypeLoadException ex)
         {
+            _unresolvedDependencies = DependencyDiagnostics.ExtractUnresolved(ex);
             return ex.Types.Where(t => t != null).Cast<Type>();
         }
     }

--- a/src/runtime/Inspection/MetadataResolverFactory.cs
+++ b/src/runtime/Inspection/MetadataResolverFactory.cs
@@ -5,22 +5,30 @@ namespace Sherlock.MCP.Runtime.Inspection;
 
 internal static class MetadataResolverFactory
 {
-    public static PathAssemblyResolver Create(string assemblyPath)
+    public static PathAssemblyResolver Create(string assemblyPath, IReadOnlyList<string>? additionalSearchDirectories = null)
     {
         var comparer = StringComparer.OrdinalIgnoreCase;
         var paths = new HashSet<string>(comparer);
+        var simpleNames = new HashSet<string>(comparer);
 
         var fullPath = Path.GetFullPath(assemblyPath);
-        if (File.Exists(fullPath)) paths.Add(fullPath);
+        if (File.Exists(fullPath)) AddPath(paths, simpleNames, fullPath);
 
-        var assemblyDir = Path.GetDirectoryName(fullPath);
-        AddDllsFromDirectory(paths, assemblyDir);
-        AddDllsFromDirectory(paths, RuntimeEnvironment.GetRuntimeDirectory());
+        AddDllsFromDirectory(paths, simpleNames, Path.GetDirectoryName(fullPath));
+        AddDllsFromDirectory(paths, simpleNames, RuntimeEnvironment.GetRuntimeDirectory());
+
+        if (additionalSearchDirectories != null)
+            foreach (var directory in additionalSearchDirectories)
+                AddDllsFromDirectory(paths, simpleNames, directory);
+
+        if (NuGetCacheProbe.TryParseCacheLayout(fullPath, out var consumingTfm, out var packageId))
+            foreach (var dll in NuGetCacheProbe.EnumerateCandidateDependencyDlls(consumingTfm, packageId))
+                AddPath(paths, simpleNames, dll);
 
         return new PathAssemblyResolver(paths);
     }
 
-    private static void AddDllsFromDirectory(HashSet<string> paths, string? directory)
+    private static void AddDllsFromDirectory(HashSet<string> paths, HashSet<string> simpleNames, string? directory)
     {
         if (string.IsNullOrWhiteSpace(directory)) return;
 
@@ -28,11 +36,15 @@ internal static class MetadataResolverFactory
         {
             if (!Directory.Exists(directory)) return;
             foreach (var dll in Directory.EnumerateFiles(directory, "*.dll", SearchOption.TopDirectoryOnly))
-            {
-                try { paths.Add(Path.GetFullPath(dll)); }
-                catch { }
-            }
+                AddPath(paths, simpleNames, dll);
         }
         catch { }
+    }
+
+    private static void AddPath(HashSet<string> paths, HashSet<string> simpleNames, string dll)
+    {
+        if (!simpleNames.Add(Path.GetFileNameWithoutExtension(dll))) return;
+        try { paths.Add(Path.GetFullPath(dll)); }
+        catch { simpleNames.Remove(Path.GetFileNameWithoutExtension(dll)); }
     }
 }

--- a/src/runtime/Inspection/NuGetCacheProbe.cs
+++ b/src/runtime/Inspection/NuGetCacheProbe.cs
@@ -46,7 +46,7 @@ internal static class NuGetCacheProbe
         var cacheRoot = GetCacheRoot();
         if (string.IsNullOrWhiteSpace(cacheRoot) || !Directory.Exists(cacheRoot)) return candidates;
 
-        foreach (var packageDir in SafeEnumerateDirectories(cacheRoot))
+        foreach (var packageDir in SafeEnumerateDirectories(cacheRoot).OrderBy(d => d, StringComparer.Ordinal))
         {
             var packageName = Path.GetFileName(packageDir);
             if (packageName.Equals(excludePackageId, StringComparison.OrdinalIgnoreCase)) continue;
@@ -63,7 +63,7 @@ internal static class NuGetCacheProbe
                 var tfm = PickCompatibleTfm(tfms, consumingTfm);
                 if (tfm is null) continue;
 
-                candidates.AddRange(Directory.EnumerateFiles(Path.Combine(libDir, tfm), "*.dll", SearchOption.TopDirectoryOnly));
+                candidates.AddRange(Directory.GetFiles(Path.Combine(libDir, tfm), "*.dll", SearchOption.TopDirectoryOnly).OrderBy(f => f, StringComparer.Ordinal));
             }
             catch { }
         }
@@ -113,21 +113,84 @@ internal static class NuGetCacheProbe
     {
         var exact = availableTfms.FirstOrDefault(t => t.Equals(requested, StringComparison.OrdinalIgnoreCase));
         if (exact is not null) return exact;
+
+        var target = ParseTfm(requested);
         return availableTfms
-            .Where(t => IsCompatibleFramework(t, requested))
-            .OrderByDescending(t => t, StringComparer.OrdinalIgnoreCase)
+            .Select(t => (raw: t, parsed: ParseTfm(t)))
+            .Where(t => IsCompatible(t.parsed, target))
+            .OrderByDescending(t => CompatibilityRank(t.parsed.family, target.family))
+            .ThenByDescending(t => t.parsed.version)
+            .ThenBy(t => t.raw, StringComparer.OrdinalIgnoreCase)
+            .Select(t => t.raw)
             .FirstOrDefault();
     }
 
-    private static bool IsCompatibleFramework(string availableFramework, string targetFramework)
-    {
-        if (availableFramework.Equals(targetFramework, StringComparison.OrdinalIgnoreCase)) return true;
-        if (targetFramework.StartsWith("net", StringComparison.Ordinal) && !targetFramework.Contains("framework"))
+    private static bool IsCompatible((TfmFamily family, Version version) available, (TfmFamily family, Version version) target) =>
+        target.family switch
         {
-            if (availableFramework.Equals("netstandard2.0", StringComparison.OrdinalIgnoreCase) ||
-                availableFramework.Equals("netstandard2.1", StringComparison.OrdinalIgnoreCase))
-                return true;
+            TfmFamily.NetCore => available.family switch
+            {
+                TfmFamily.NetCore => available.version <= target.version,
+                TfmFamily.NetCoreApp => true,
+                TfmFamily.NetStandard => available.version <= new Version(2, 1),
+                _ => false
+            },
+            TfmFamily.NetCoreApp => available.family switch
+            {
+                TfmFamily.NetCoreApp => available.version <= target.version,
+                TfmFamily.NetStandard => available.version <= new Version(2, 1),
+                _ => false
+            },
+            TfmFamily.NetStandard => available.family == TfmFamily.NetStandard && available.version <= target.version,
+            TfmFamily.NetFramework => (available.family == TfmFamily.NetFramework && available.version <= target.version)
+                || (available.family == TfmFamily.NetStandard && available.version <= new Version(2, 0)),
+            _ => false
+        };
+
+    private static int CompatibilityRank(TfmFamily available, TfmFamily target)
+    {
+        if (available == target) return 3;
+        return available switch
+        {
+            TfmFamily.NetCore or TfmFamily.NetCoreApp => 2,
+            TfmFamily.NetStandard => 1,
+            _ => 0
+        };
+    }
+
+    private enum TfmFamily { NetCore, NetCoreApp, NetStandard, NetFramework, Unknown }
+
+    private static (TfmFamily family, Version version) ParseTfm(string tfm)
+    {
+        var lower = tfm.ToLowerInvariant();
+        if (lower.StartsWith("netstandard", StringComparison.Ordinal))
+            return (TfmFamily.NetStandard, TryParseVersion(lower[11..]) ?? new Version(0, 0));
+        if (lower.StartsWith("netcoreapp", StringComparison.Ordinal))
+            return (TfmFamily.NetCoreApp, TryParseVersion(lower[10..]) ?? new Version(0, 0));
+        if (lower.StartsWith("net", StringComparison.Ordinal) && !lower.Contains("framework"))
+        {
+            var rest = lower[3..];
+            if (IsFrameworkStyleTfm(rest))
+                return (TfmFamily.NetFramework, ParseFrameworkStyleVersion(rest));
+            var version = TryParseVersion(rest);
+            if (version is not null) return (TfmFamily.NetCore, version);
         }
-        return false;
+        return (TfmFamily.Unknown, new Version(0, 0));
+    }
+
+    private static bool IsFrameworkStyleTfm(string rest)
+    {
+        if (rest.Length is not (2 or 3)) return false;
+        foreach (var ch in rest)
+            if (!char.IsDigit(ch)) return false;
+        return rest[0] is >= '1' and <= '4';
+    }
+
+    private static Version ParseFrameworkStyleVersion(string rest)
+    {
+        var major = rest[0] - '0';
+        var minor = rest[1] - '0';
+        if (rest.Length == 2) return new Version(major, minor);
+        return new Version(major, minor, rest[2] - '0');
     }
 }

--- a/src/runtime/Inspection/NuGetCacheProbe.cs
+++ b/src/runtime/Inspection/NuGetCacheProbe.cs
@@ -1,0 +1,133 @@
+namespace Sherlock.MCP.Runtime.Inspection;
+
+internal static class NuGetCacheProbe
+{
+    private static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+    public static string GetCacheRoot()
+    {
+        var overridePath = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (!string.IsNullOrWhiteSpace(overridePath)) return overridePath;
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(userProfile, ".nuget", "packages");
+    }
+
+    public static bool TryParseCacheLayout(string fullAssemblyPath, out string consumingTfm, out string packageId)
+    {
+        consumingTfm = "";
+        packageId = "";
+
+        var cacheRoot = GetCacheRoot();
+        if (string.IsNullOrWhiteSpace(cacheRoot) || !Directory.Exists(cacheRoot)) return false;
+
+        var fullCacheRoot = Path.GetFullPath(cacheRoot);
+        var normalized = Path.GetFullPath(fullAssemblyPath);
+        if (!normalized.StartsWith(EnsureTrailingSeparator(fullCacheRoot), PathComparison)) return false;
+
+        var relative = Path.GetRelativePath(fullCacheRoot, normalized);
+        var segments = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (segments.Length < 5) return false;
+
+        var folderKind = segments[2];
+        if (!folderKind.Equals("lib", StringComparison.OrdinalIgnoreCase) && !folderKind.Equals("ref", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        packageId = segments[0];
+        consumingTfm = segments[3];
+        return true;
+    }
+
+    public static List<string> EnumerateCandidateDependencyDlls(string consumingTfm, string excludePackageId)
+    {
+        var candidates = new List<string>();
+        var cacheRoot = GetCacheRoot();
+        if (string.IsNullOrWhiteSpace(cacheRoot) || !Directory.Exists(cacheRoot)) return candidates;
+
+        foreach (var packageDir in SafeEnumerateDirectories(cacheRoot))
+        {
+            var packageName = Path.GetFileName(packageDir);
+            if (packageName.Equals(excludePackageId, StringComparison.OrdinalIgnoreCase)) continue;
+
+            try
+            {
+                var version = PickHighestVersion(SafeEnumerateDirectories(packageDir).Select(Path.GetFileName).Where(n => n is not null).Cast<string>().ToArray());
+                if (version is null) continue;
+
+                var libDir = Path.Combine(packageDir, version, "lib");
+                if (!Directory.Exists(libDir)) continue;
+
+                var tfms = SafeEnumerateDirectories(libDir).Select(Path.GetFileName).Where(n => n is not null).Cast<string>().ToArray();
+                var tfm = PickCompatibleTfm(tfms, consumingTfm);
+                if (tfm is null) continue;
+
+                candidates.AddRange(Directory.EnumerateFiles(Path.Combine(libDir, tfm), "*.dll", SearchOption.TopDirectoryOnly));
+            }
+            catch { }
+        }
+        return candidates;
+    }
+
+    private static string[] SafeEnumerateDirectories(string directory)
+    {
+        try
+        {
+            return Directory.GetDirectories(directory);
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static string EnsureTrailingSeparator(string path) =>
+        path.EndsWith(Path.DirectorySeparatorChar) ? path : path + Path.DirectorySeparatorChar;
+
+    private static string? PickHighestVersion(string[] versions)
+    {
+        if (versions.Length == 0) return null;
+        var parsed = versions
+            .Select(v => (raw: v, parsed: TryParseVersion(v), isStable: !v.Contains('-')))
+            .Where(p => p.parsed is not null)
+            .ToArray();
+        if (parsed.Length > 0)
+            return parsed
+                .OrderByDescending(p => p.isStable)
+                .ThenByDescending(p => p.parsed!)
+                .ThenByDescending(p => p.raw, StringComparer.OrdinalIgnoreCase)
+                .First().raw;
+        return versions.OrderByDescending(v => v, StringComparer.OrdinalIgnoreCase).First();
+    }
+
+    private static Version? TryParseVersion(string raw)
+    {
+        var core = raw.AsSpan();
+        var cut = core.IndexOfAny('-', '+');
+        if (cut >= 0) core = core[..cut];
+        return Version.TryParse(core, out var v) ? v : null;
+    }
+
+    private static string? PickCompatibleTfm(string[] availableTfms, string requested)
+    {
+        var exact = availableTfms.FirstOrDefault(t => t.Equals(requested, StringComparison.OrdinalIgnoreCase));
+        if (exact is not null) return exact;
+        return availableTfms
+            .Where(t => IsCompatibleFramework(t, requested))
+            .OrderByDescending(t => t, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+    }
+
+    private static bool IsCompatibleFramework(string availableFramework, string targetFramework)
+    {
+        if (availableFramework.Equals(targetFramework, StringComparison.OrdinalIgnoreCase)) return true;
+        if (targetFramework.StartsWith("net", StringComparison.Ordinal) && !targetFramework.Contains("framework"))
+        {
+            if (availableFramework.Equals("netstandard2.0", StringComparison.OrdinalIgnoreCase) ||
+                availableFramework.Equals("netstandard2.1", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/runtime/Inspection/SharedInspectionContextProvider.cs
+++ b/src/runtime/Inspection/SharedInspectionContextProvider.cs
@@ -75,10 +75,10 @@ public sealed class SharedInspectionContextProvider : IInspectionContextProvider
 
     public SharedInspectionContextProvider(RuntimeOptions options) => _options = options;
 
-    public InspectionContextLease Acquire(string assemblyPath, bool forceRuntimeLoad = false)
+    public InspectionContextLease Acquire(string assemblyPath, bool forceRuntimeLoad = false, IReadOnlyList<string>? additionalSearchDirectories = null)
     {
         var fullPath = Path.GetFullPath(assemblyPath);
-        var key = forceRuntimeLoad ? $"{fullPath}|runtime" : fullPath;
+        var key = (forceRuntimeLoad ? $"{fullPath}|runtime" : fullPath) + BuildDepsKey(additionalSearchDirectories);
         var fileInfo = new FileInfo(fullPath);
         if (!fileInfo.Exists)
             throw new FileNotFoundException($"Assembly file not found: {fullPath}", fullPath);
@@ -89,7 +89,7 @@ public sealed class SharedInspectionContextProvider : IInspectionContextProvider
         while (true)
         {
             var lazy = _entries.GetOrAdd(key, _ => new Lazy<Entry>(
-                () => new Entry(InspectionContextFactory.Create(fullPath, forceRuntimeLoad), stampTicks, length),
+                () => new Entry(InspectionContextFactory.Create(fullPath, forceRuntimeLoad, additionalSearchDirectories), stampTicks, length),
                 LazyThreadSafetyMode.ExecutionAndPublication));
 
             Entry entry;
@@ -130,6 +130,22 @@ public sealed class SharedInspectionContextProvider : IInspectionContextProvider
             if (pair.Value.IsValueCreated)
                 pair.Value.Value.Retire();
         }
+    }
+
+    private static string BuildDepsKey(IReadOnlyList<string>? directories)
+    {
+        if (directories == null || directories.Count == 0) return "";
+
+        var normalized = directories
+            .Where(d => !string.IsNullOrWhiteSpace(d))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(d => d, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (normalized.Length == 0) return "";
+
+        var bytes = System.Text.Encoding.UTF8.GetBytes(string.Join("|", normalized));
+        return "|deps:" + Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes))[..16];
     }
 
     private void EvictOverflow()

--- a/src/runtime/TypeAnalysisService.cs
+++ b/src/runtime/TypeAnalysisService.cs
@@ -226,27 +226,47 @@ public class TypeAnalysisService : ITypeAnalysisService, IDisposable
         }
     }
 
-    public TypeAnalysisInfo[] GetTypesFromAssembly(string assemblyPath)
+    public TypeAnalysisInfo[] GetTypesFromAssembly(string assemblyPath, IReadOnlyList<string>? additionalSearchDirectories = null)
     {
+        using var lease = _contexts.Acquire(assemblyPath, additionalSearchDirectories: additionalSearchDirectories);
+        var context = lease.Context;
+        TypeAnalysisInfo[] types;
         try
         {
-            using var lease = _contexts.Acquire(assemblyPath);
-            return lease.Context.GetTypes()
+            types = context.GetTypes()
                 .Where(t => t.IsPublic || t.IsNestedPublic)
                 .Select(GetTypeInfo)
                 .ToArray();
         }
         catch (ReflectionTypeLoadException ex)
         {
-            return ex.Types
+            var unresolved = Combine(context.UnresolvedDependencies, DependencyDiagnostics.ExtractUnresolved(ex));
+            if (unresolved.Length > 0)
+                throw new DependencyResolutionException(assemblyPath, unresolved);
+            types = ex.Types
                 .Where(t => t != null && (t.IsPublic || t.IsNestedPublic))
                 .Select(t => GetTypeInfo(t!))
                 .ToArray();
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            return [];
+            var unresolved = Combine(context.UnresolvedDependencies, DependencyDiagnostics.ExtractUnresolved(ex));
+            if (unresolved.Length == 0) throw;
+            throw new DependencyResolutionException(assemblyPath, unresolved);
         }
+
+        if (types.Length == 0 && context.UnresolvedDependencies.Count > 0)
+            throw new DependencyResolutionException(assemblyPath, context.UnresolvedDependencies);
+
+        return types;
+    }
+
+    private static string[] Combine(IReadOnlyList<string> existing, params string?[] extras)
+    {
+        var names = new SortedSet<string>(existing, StringComparer.OrdinalIgnoreCase);
+        foreach (var extra in extras)
+            if (!string.IsNullOrWhiteSpace(extra)) names.Add(extra);
+        return names.ToArray();
     }
 
     private static bool InheritsFromDelegate(Type type)

--- a/src/server/Sherlock.MCP.Server.csproj
+++ b/src/server/Sherlock.MCP.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.11.0</Version>
+    <Version>2.12.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/server/Tools/TypeAnalysisTools.cs
+++ b/src/server/Tools/TypeAnalysisTools.cs
@@ -22,7 +22,8 @@ public static class TypeAnalysisTools
         [Description("Maximum number of types to return (default: 50)")] int? maxItems = null,
         [Description("Items to skip (paging)")] int? skip = null,
         [Description("Continuation token for paging")] string? continuationToken = null,
-        [Description("Response shape. 'summary' (default, token-lean): { FullName, Namespace, Kind } only - use for browsing/searching. 'full': adds attributes, base type, interfaces, generic params, nested types - use only when you need those fields on every item.")] string projection = "summary")
+        [Description("Response shape. 'summary' (default, token-lean): { FullName, Namespace, Kind } only - use for browsing/searching. 'full': adds attributes, base type, interfaces, generic params, nested types - use only when you need those fields on every item.")] string projection = "summary",
+        [Description("Optional paths to dependency assemblies (.dll) to help resolve types. Only needed when types fail to resolve and the assembly's dependencies are not next to it or in the NuGet cache - e.g. point at sibling DLLs in a build-output folder.")] string[]? additionalAssemblies = null)
     {
         try
         {
@@ -33,7 +34,21 @@ public static class TypeAnalysisTools
             if (normalizedProjection != "summary" && normalizedProjection != "full")
                 return JsonHelpers.Error("InvalidProjection", "projection must be 'summary' or 'full'");
 
-            var allTypes = typeAnalysis.GetTypesFromAssembly(assemblyPath);
+            string[]? searchDirectories = null;
+            if (additionalAssemblies is { Length: > 0 })
+            {
+                var scope = AssemblyScope.BuildAndValidate(assemblyPath, additionalAssemblies);
+                if (scope.Error != null)
+                    return scope.Error;
+                searchDirectories = scope.Paths
+                    .Select(Path.GetDirectoryName)
+                    .Where(d => !string.IsNullOrEmpty(d))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Cast<string>()
+                    .ToArray();
+            }
+
+            var allTypes = typeAnalysis.GetTypesFromAssembly(assemblyPath, searchDirectories);
 
             // Pagination logic
             var defaultPageSize = 50;
@@ -73,6 +88,13 @@ public static class TypeAnalysisTools
                 types
             };
             return JsonHelpers.Envelope("type.list", result);
+        }
+        catch (DependencyResolutionException ex)
+        {
+            return JsonHelpers.ErrorWithGuidance(
+                "DependencyResolutionFailed",
+                ex.Message,
+                suggestion: $"The dependencies ({string.Join(", ", ex.UnresolvedDependencies)}) were not found next to the assembly or in the NuGet cache. Point assemblyPath at a build-output directory (e.g. bin/Debug/<tfm>) that contains these DLLs, or pass their folder via additionalAssemblies.");
         }
         catch (Exception ex)
         {

--- a/src/server/Tools/TypeAnalysisTools.cs
+++ b/src/server/Tools/TypeAnalysisTools.cs
@@ -55,7 +55,10 @@ public static class TypeAnalysisTools
             var pageSize = Math.Max(1, maxItems ?? defaultPageSize);
             var offset = 0;
 
-            var cacheKey = $"types_from_assembly_{CacheKeyHelper.FileStamp(assemblyPath)}_{pageSize}";
+            var dependencyScope = searchDirectories is { Length: > 0 }
+                ? string.Join("|", searchDirectories.OrderBy(d => d, StringComparer.OrdinalIgnoreCase))
+                : "";
+            var cacheKey = $"types_from_assembly_{CacheKeyHelper.FileStamp(assemblyPath)}_{pageSize}_{dependencyScope}";
             var salt = TokenHelper.MakeSalt(cacheKey);
 
             if (!string.IsNullOrWhiteSpace(continuationToken))
@@ -94,7 +97,7 @@ public static class TypeAnalysisTools
             return JsonHelpers.ErrorWithGuidance(
                 "DependencyResolutionFailed",
                 ex.Message,
-                suggestion: $"The dependencies ({string.Join(", ", ex.UnresolvedDependencies)}) were not found next to the assembly or in the NuGet cache. Point assemblyPath at a build-output directory (e.g. bin/Debug/<tfm>) that contains these DLLs, or pass their folder via additionalAssemblies.");
+                suggestion: $"The dependencies ({string.Join(", ", ex.UnresolvedDependencies)}) were not found next to the assembly or in the NuGet cache. Re-run with assemblyPath pointing at a copy of the assembly in a build-output folder (e.g. bin/Debug/<tfm>/Name.dll) whose sibling DLLs include these dependencies, or pass the dependency DLL file paths via additionalAssemblies.");
         }
         catch (Exception ex)
         {

--- a/src/unit-tests/DependencyResolutionTests.cs
+++ b/src/unit-tests/DependencyResolutionTests.cs
@@ -1,0 +1,101 @@
+using System.Reflection;
+using Sherlock.MCP.Runtime;
+using Sherlock.MCP.Runtime.Inspection;
+
+namespace Sherlock.MCP.Tests;
+
+// Public type deriving from a Sherlock.MCP.Runtime type, so loading this assembly in
+// isolation (without Sherlock.MCP.Runtime.dll alongside) forces a dependency resolution.
+public class RuntimeDerivedFixture : TypeAnalysisService { }
+
+public class DependencyResolutionTests
+{
+    [Fact]
+    public void IsolatedAssembly_SurfacesDependencyResolutionError()
+    {
+        using var isolated = new IsolatedCopy();
+        using var service = new TypeAnalysisService();
+
+        var ex = Assert.Throws<DependencyResolutionException>(() => service.GetTypesFromAssembly(isolated.DllPath));
+
+        Assert.NotEmpty(ex.UnresolvedDependencies);
+    }
+
+    [Fact]
+    public void AdditionalSearchDirectories_ResolveDependencies()
+    {
+        using var isolated = new IsolatedCopy();
+        var binDirectory = Path.GetDirectoryName(typeof(RuntimeDerivedFixture).Assembly.Location)!;
+
+        using var ctx = new MetadataOnlyInspectionContext(isolated.DllPath, new[] { binDirectory });
+        var types = ctx.GetTypes().ToArray();
+
+        Assert.Empty(ctx.UnresolvedDependencies);
+        Assert.Contains(types, t => t.Name == nameof(RuntimeDerivedFixture));
+    }
+
+    [Fact]
+    public void GetTypesFromAssembly_ThrowsDependencyResolution_WhenEmptyAndUnresolved()
+    {
+        using var service = new TypeAnalysisService(new StubProvider(["Azure.Core", "Azure.ResourceManager"]));
+
+        var ex = Assert.Throws<DependencyResolutionException>(() => service.GetTypesFromAssembly("ignored.dll"));
+
+        Assert.Contains("Azure.Core", ex.UnresolvedDependencies);
+        Assert.Contains("Azure.ResourceManager", ex.UnresolvedDependencies);
+    }
+
+    [Fact]
+    public void Acquire_WithDifferentSearchDirectories_UsesDistinctContexts()
+    {
+        using var provider = new SharedInspectionContextProvider(new RuntimeOptions());
+        var path = typeof(RuntimeDerivedFixture).Assembly.Location;
+
+        using var a = provider.Acquire(path);
+        using var b = provider.Acquire(path);
+        using var c = provider.Acquire(path, additionalSearchDirectories: new[] { Path.GetTempPath() });
+
+        Assert.Same(a.Context, b.Context);
+        Assert.NotSame(a.Context, c.Context);
+    }
+
+    private sealed class IsolatedCopy : IDisposable
+    {
+        public IsolatedCopy()
+        {
+            var source = typeof(RuntimeDerivedFixture).Assembly.Location;
+            Directory = Path.Combine(Path.GetTempPath(), $"sherlock_isolated_{Guid.NewGuid():N}");
+            System.IO.Directory.CreateDirectory(Directory);
+            DllPath = Path.Combine(Directory, Path.GetFileName(source));
+            File.Copy(source, DllPath);
+        }
+
+        public string Directory { get; }
+
+        public string DllPath { get; }
+
+        public void Dispose()
+        {
+            try { System.IO.Directory.Delete(Directory, recursive: true); } catch { }
+        }
+    }
+
+    private sealed class StubProvider(string[] unresolved) : IInspectionContextProvider
+    {
+        public InspectionContextLease Acquire(string assemblyPath, bool forceRuntimeLoad = false, IReadOnlyList<string>? additionalSearchDirectories = null) =>
+            new(new StubContext(unresolved), () => { });
+    }
+
+    private sealed class StubContext(string[] unresolved) : IAssemblyInspectionContext
+    {
+        public Assembly Assembly => typeof(StubContext).Assembly;
+
+        public IReadOnlyList<string> UnresolvedDependencies => unresolved;
+
+        public IEnumerable<Type> GetTypes() => [];
+
+        public MemberInfo[] GetMembers(Type type, BindingFlags flags) => [];
+
+        public void Dispose() { }
+    }
+}

--- a/src/unit-tests/NuGetCacheProbeTests.cs
+++ b/src/unit-tests/NuGetCacheProbeTests.cs
@@ -53,19 +53,55 @@ public class NuGetCacheProbeTests
         Assert.Contains(candidates, c => string.Equals(c, dependency, StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void EnumerateCandidateDependencyDlls_AcceptsLowerNetTfm()
+    {
+        using var cache = new TempCache();
+        cache.AddPackageDll("pkga", "1.0.0", "net8.0", "PkgA.dll");
+        var dependency = cache.AddPackageDll("depb", "2.0.0", "net6.0", "DepB.dll");
+
+        var candidates = NuGetCacheProbe.EnumerateCandidateDependencyDlls("net8.0", "pkga");
+
+        Assert.Contains(candidates, c => string.Equals(c, dependency, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void EnumerateCandidateDependencyDlls_PrefersNearestCompatibleTfm()
+    {
+        using var cache = new TempCache();
+        cache.AddPackageDll("pkga", "1.0.0", "net8.0", "PkgA.dll");
+        cache.AddPackageDll("depb", "2.0.0", "net6.0", "DepB.dll");
+        var preferred = cache.AddPackageDll("depb", "2.0.0", "net8.0", "DepB.dll");
+
+        var candidates = NuGetCacheProbe.EnumerateCandidateDependencyDlls("net8.0", "pkga");
+
+        Assert.Contains(preferred, candidates);
+        Assert.DoesNotContain(candidates, c => c.Contains($"{Path.DirectorySeparatorChar}net6.0{Path.DirectorySeparatorChar}"));
+    }
+
     private sealed class TempCache : IDisposable
     {
+        private static readonly object EnvLock = new();
         private readonly string? _previous;
 
         public TempCache()
         {
-            Root = Path.Combine(Path.GetTempPath(), $"sherlock_cache_{Guid.NewGuid():N}");
-            Directory.CreateDirectory(Root);
-            _previous = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", Root);
+            Monitor.Enter(EnvLock);
+            try
+            {
+                Root = Path.Combine(Path.GetTempPath(), $"sherlock_cache_{Guid.NewGuid():N}");
+                Directory.CreateDirectory(Root);
+                _previous = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+                Environment.SetEnvironmentVariable("NUGET_PACKAGES", Root);
+            }
+            catch
+            {
+                Monitor.Exit(EnvLock);
+                throw;
+            }
         }
 
-        public string Root { get; }
+        public string Root { get; } = "";
 
         public string AddPackageDll(string packageId, string version, string tfm, string fileName)
         {
@@ -78,8 +114,15 @@ public class NuGetCacheProbeTests
 
         public void Dispose()
         {
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", _previous);
-            try { Directory.Delete(Root, recursive: true); } catch { }
+            try
+            {
+                Environment.SetEnvironmentVariable("NUGET_PACKAGES", _previous);
+                try { Directory.Delete(Root, recursive: true); } catch { }
+            }
+            finally
+            {
+                Monitor.Exit(EnvLock);
+            }
         }
     }
 }

--- a/src/unit-tests/NuGetCacheProbeTests.cs
+++ b/src/unit-tests/NuGetCacheProbeTests.cs
@@ -1,0 +1,85 @@
+using Sherlock.MCP.Runtime.Inspection;
+
+namespace Sherlock.MCP.Tests;
+
+public class NuGetCacheProbeTests
+{
+    [Fact]
+    public void TryParseCacheLayout_RecognizesNuGetLibPath()
+    {
+        using var cache = new TempCache();
+        var dll = cache.AddPackageDll("pkga", "1.0.0", "net8.0", "PkgA.dll");
+
+        var parsed = NuGetCacheProbe.TryParseCacheLayout(dll, out var tfm, out var packageId);
+
+        Assert.True(parsed);
+        Assert.Equal("net8.0", tfm);
+        Assert.Equal("pkga", packageId);
+    }
+
+    [Fact]
+    public void TryParseCacheLayout_RejectsPathOutsideCache()
+    {
+        using var cache = new TempCache();
+        var outside = Path.Combine(Path.GetTempPath(), $"sherlock_outside_{Guid.NewGuid():N}.dll");
+
+        var parsed = NuGetCacheProbe.TryParseCacheLayout(outside, out _, out _);
+
+        Assert.False(parsed);
+    }
+
+    [Fact]
+    public void EnumerateCandidateDependencyDlls_FindsSibling_ExcludesSelf()
+    {
+        using var cache = new TempCache();
+        var primary = cache.AddPackageDll("pkga", "1.0.0", "net8.0", "PkgA.dll");
+        var dependency = cache.AddPackageDll("depb", "2.0.0", "net8.0", "DepB.dll");
+
+        var candidates = NuGetCacheProbe.EnumerateCandidateDependencyDlls("net8.0", "pkga");
+
+        Assert.Contains(candidates, c => string.Equals(c, dependency, StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(candidates, c => string.Equals(c, primary, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void EnumerateCandidateDependencyDlls_FallsBackToCompatibleTfm()
+    {
+        using var cache = new TempCache();
+        cache.AddPackageDll("pkga", "1.0.0", "net8.0", "PkgA.dll");
+        var dependency = cache.AddPackageDll("depb", "2.0.0", "netstandard2.0", "DepB.dll");
+
+        var candidates = NuGetCacheProbe.EnumerateCandidateDependencyDlls("net8.0", "pkga");
+
+        Assert.Contains(candidates, c => string.Equals(c, dependency, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private sealed class TempCache : IDisposable
+    {
+        private readonly string? _previous;
+
+        public TempCache()
+        {
+            Root = Path.Combine(Path.GetTempPath(), $"sherlock_cache_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Root);
+            _previous = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", Root);
+        }
+
+        public string Root { get; }
+
+        public string AddPackageDll(string packageId, string version, string tfm, string fileName)
+        {
+            var dir = Path.Combine(Root, packageId, version, "lib", tfm);
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, fileName);
+            File.WriteAllText(path, "");
+            return path;
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", _previous);
+            try { Directory.Delete(Root, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`GetTypesFromAssembly` returned a **silent empty result** when pointed at an assembly in an isolated NuGet `lib/<tfm>` folder (e.g. `~/.nuget/packages/.../lib/net8.0/Foo.dll`), because the `MetadataLoadContext` resolver only looked in the assembly's own directory + the .NET runtime dir. Dependencies like `Azure.Core` / `Azure.ResourceManager` couldn't be resolved, so type projection threw `FileNotFoundException`, which a blanket `catch { return []; }` masked. This was hit while introspecting `Azure.ResourceManager.MachineLearning`.

This change (full fix):

- **Auto-resolves transitive dependencies from the NuGet global packages cache** (`NuGetCacheProbe`). When an assembly is loaded from a cache `lib/<tfm>` layout, the resolver probes the cache for the best framework-compatible build of each sibling package. Makes bare NuGet assemblies introspectable without a build output.
- **`additionalAssemblies` override** on `GetTypesFromAssembly` — point at sibling dependency DLLs (e.g. `bin/Debug/<tfm>`) when auto-probing is insufficient. This is also now threaded into the resolver (previously `additionalAssemblies` never reached it).
- **No more silent empty** — surfaces a structured `DependencyResolutionFailed` error naming the unresolved assemblies and how to supply them (`DependencyResolutionException` / `DependencyDiagnostics`).
- Resolver simple-name dedupe (own-dir/runtime win over cache copies), cache-key now incorporates the dependency scope, and parity for the `forceRuntimeLoad` load path.
- Version bump 2.11.0 → 2.12.0 (csproj, server.json, CHANGELOG).

## Test plan

- New `NuGetCacheProbeTests` (cache-layout parsing, candidate enumeration, TFM fallback) and `DependencyResolutionTests` (isolated assembly throws `DependencyResolutionException`, `additionalSearchDirectories` resolves, stubbed empty+unresolved throws, distinct cache keys per scope).
- Verified end-to-end against the real `Azure.ResourceManager.MachineLearning` NuGet-cache DLL: now returns types via the auto-probe (was empty).
- `dotnet test` green: 188 unit tests on net8.0 + net10.0, 7 integration tests on net10.0. Clean build (warnings-as-errors).