### PR TITLE
ci(release): use NuGet trusted publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,14 @@ jobs:
           files: ./artifacts/*.nupkg
           generate_release_notes: false
 
+      - name: NuGet login (OIDC -> temp API key)
+        uses: NuGet/login@v1
+        id: nuget_login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish to NuGet
-        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ steps.nuget_login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Wait for NuGet indexing
         run: |


### PR DESCRIPTION
## Summary
- Replace the long-lived `NUGET_API_KEY` secret with NuGet.org's Trusted Publishing flow.
- Adds a `NuGet/login@v1` step that exchanges the workflow's GitHub OIDC token for a short-lived (1 hour) NuGet API key using the `NUGET_USER` secret, right before the publish step.
- Updates the `dotnet nuget push` step to use the temporary key from that step's output.

## Test plan
- [ ] Trusted Publishing policy is already configured on nuget.org for this repo/workflow (`release.yml`), no Environment restriction.
- [ ] `NUGET_USER` secret is set in repo settings.
- [ ] On the next release tag push, confirm the "NuGet login" step in Actions succeeds and the publish step pushes successfully.
- [ ] Delete the now-unused `NUGET_API_KEY` secret afterward.